### PR TITLE
Fix various callback compiler errors

### DIFF
--- a/include/lexy/callback.hpp
+++ b/include/lexy/callback.hpp
@@ -286,7 +286,7 @@ struct _list
         template <typename U>
         auto operator()(U&& obj) -> decltype(_result.push_back(LEXY_FWD(obj)))
         {
-            _result.push_back(LEXY_FWD(obj));
+            return _result.push_back(LEXY_FWD(obj));
         }
 
         template <typename... Args>

--- a/include/lexy/callback.hpp
+++ b/include/lexy/callback.hpp
@@ -290,7 +290,7 @@ struct _list
         }
 
         template <typename... Args>
-        auto operator()(Args&&... args) -> std::enable_if_t<(sizeof...(Args) > 1)>
+        void operator()(Args&&... args)
         {
             _result.emplace_back(LEXY_FWD(args)...);
         }
@@ -338,7 +338,7 @@ struct _collection
         }
 
         template <typename... Args>
-        auto operator()(Args&&... args) -> std::enable_if_t<(sizeof...(Args) > 1)>
+        void operator()(Args&&... args)
         {
             _result.emplace(LEXY_FWD(args)...);
         }

--- a/include/lexy/callback.hpp
+++ b/include/lexy/callback.hpp
@@ -279,7 +279,7 @@ struct _list
 
     struct _sink
     {
-        T _result;
+        T _result{};
 
         using return_type = T;
 
@@ -328,7 +328,7 @@ struct _collection
 
     struct _sink
     {
-        T _result;
+        T _result{};
 
         using return_type = T;
 
@@ -498,7 +498,7 @@ struct _as_string
 
     struct _sink
     {
-        String _result;
+        String _result{};
 
         using return_type = String;
 

--- a/include/lexy/callback.hpp
+++ b/include/lexy/callback.hpp
@@ -283,14 +283,12 @@ struct _list
 
         using return_type = T;
 
-        void operator()(const typename T::value_type& obj)
+        template <typename U>
+        auto operator()(U&& obj) -> decltype(_result.push_back(LEXY_FWD(obj)))
         {
-            _result.push_back(obj);
+            _result.push_back(LEXY_FWD(obj));
         }
-        void operator()(typename T::value_type&& obj)
-        {
-            _result.push_back(LEXY_MOV(obj));
-        }
+
         template <typename... Args>
         auto operator()(Args&&... args) -> std::enable_if_t<(sizeof...(Args) > 1)>
         {
@@ -302,6 +300,7 @@ struct _list
             return LEXY_MOV(_result);
         }
     };
+
     constexpr auto sink() const
     {
         return _sink{};
@@ -332,14 +331,12 @@ struct _collection
 
         using return_type = T;
 
-        void operator()(const typename T::value_type& obj)
+        template <typename U>
+        auto operator()(U&& obj) -> decltype(_result.insert(LEXY_FWD(obj)))
         {
-            _result.insert(obj);
+            return _result.insert(LEXY_FWD(obj));
         }
-        void operator()(typename T::value_type&& obj)
-        {
-            _result.insert(LEXY_MOV(obj));
-        }
+
         template <typename... Args>
         auto operator()(Args&&... args) -> std::enable_if_t<(sizeof...(Args) > 1)>
         {
@@ -351,6 +348,7 @@ struct _collection
             return LEXY_MOV(_result);
         }
     };
+
     constexpr auto sink() const
     {
         return _sink{};


### PR DESCRIPTION
Removes hidden dependencies on `value_type` and ensures types with explicit constructors can be intialized.
Fixes #12 