### PR TITLE
ensure lexy::_detail::lazy_init selects the correct storage

### DIFF
--- a/include/lexy/_detail/lazy_init.hpp
+++ b/include/lexy/_detail/lazy_init.hpp
@@ -81,10 +81,12 @@ struct _lazy_init_storage_non_trivial
     }
 };
 
+// https://github.com/foonathan/lexy/pull/17
 template <typename T>
-using _lazy_init_storage
-    = std::conditional_t<std::is_trivially_copyable_v<T> && std::is_trivially_copy_assignable_v<T>,
-                         _lazy_init_storage_trivial<T>, _lazy_init_storage_non_trivial<T>>;
+using _lazy_init_storage = std::conditional_t<
+    std::is_trivially_destructible_v<
+        T> && std::is_trivially_move_constructible_v<T> && std::is_trivially_move_assignable_v<T>,
+    _lazy_init_storage_trivial<T>, _lazy_init_storage_non_trivial<T>>;
 
 template <typename T>
 class lazy_init : _lazy_init_storage<T>

--- a/include/lexy/_detail/lazy_init.hpp
+++ b/include/lexy/_detail/lazy_init.hpp
@@ -83,8 +83,8 @@ struct _lazy_init_storage_non_trivial
 
 template <typename T>
 using _lazy_init_storage
-    = std::conditional_t<std::is_trivially_copyable_v<T>, _lazy_init_storage_trivial<T>,
-                         _lazy_init_storage_non_trivial<T>>;
+    = std::conditional_t<std::is_trivially_copyable_v<T> && std::is_trivially_copy_assignable_v<T>,
+                         _lazy_init_storage_trivial<T>, _lazy_init_storage_non_trivial<T>>;
 
 template <typename T>
 class lazy_init : _lazy_init_storage<T>
@@ -170,4 +170,3 @@ private:
 } // namespace lexy::_detail
 
 #endif // LEXY_DETAIL_LAZY_INIT_HPP_INCLUDED
-

--- a/include/lexy/result.hpp
+++ b/include/lexy/result.hpp
@@ -131,10 +131,12 @@ struct _result_storage_non_trivial
     }
 };
 
+// https://github.com/foonathan/lexy/pull/17
 template <typename T, typename E>
-using _result_storage_impl
-    = std::conditional_t<std::is_trivially_copyable_v<T> && std::is_trivially_copyable_v<E>,
-                         _result_storage_trivial<T, E>, _result_storage_non_trivial<T, E>>;
+using _result_storage_impl = std::conditional_t<
+    std::is_trivially_move_constructible_v<
+        T> && std::is_trivially_move_constructible_v<E> && std::is_trivially_destructible_v<T> && std::is_trivially_destructible_v<E> && std::is_trivially_move_assignable_v<T> && std::is_trivially_move_assignable_v<E>,
+    _result_storage_trivial<T, E>, _result_storage_non_trivial<T, E>>;
 template <typename T, typename E>
 using _result_storage
     = _result_storage_impl<std::conditional_t<std::is_void_v<T>, result_value_t, T>,
@@ -252,4 +254,3 @@ public:
 } // namespace lexy
 
 #endif // LEXY_RESULT_HPP_INCLUDED
-


### PR DESCRIPTION
See this [godbolt](https://godbolt.org/z/zcjG6E) link for why this is even necessary.