### PR TITLE
Slightly adjust the description of `dsl::try_`

### DIFF
--- a/docs/content/_reference/dsl.adoc
+++ b/docs/content/_reference/dsl.adoc
@@ -720,7 +720,7 @@ Values::
   All values produced by `rule` if `rule` was parsed successfully.
   All values produced by `recovery_rule` otherwise.
 Error::
-  All errors raised by `rule` or `recovery_rule`.
+  All errors raised by `rule` and `recovery_rule`.
 
 [discrete]
 ==== `lexy::dsl::find`

--- a/docs/content/tutorial.adoc
+++ b/docs/content/tutorial.adoc
@@ -711,7 +711,7 @@ struct version
 <1> This callback will be invoked when we parse `dot_version`.
 <2> This callback will be invoked when we parse `unreleased`.
 
-The third solution is two produce three ints even if we take the `unreleased` branch.
+The third solution is to produce three ints even if we take the `unreleased` branch.
 This can be done with the `dsl::value_c<Constant>` production.
 It will accept any input without consuming anything, but it will always produce a value -- the specified `Constant`.
 So we extend the `unreleased` branch to produce three zeroes once we take the branch:
@@ -1091,7 +1091,7 @@ We then insert it wherever we need to skip whitespace.
 [source,cpp]
 ----
 // Define whitespace globally for convenience.
-constexpr auto ws = dsl::whitespace(dsl::ascii:::blank).
+constexpr auto ws = dsl::whitespace(dsl::ascii::blank).
 
 struct config
 {


### PR DESCRIPTION
Slightly adjust the description of `try_` to make it more clear that it is indeed possible to get errors from *both* branches, not just from one or the other.

Also included are some typos in the tutorial that didn't feel big enough to be worth a separate PR.