### PR TITLE
Only print a trailing newline in report_error if an error has occurred

### DIFF
--- a/include/lexy_ext/report_error.hpp
+++ b/include/lexy_ext/report_error.hpp
@@ -292,7 +292,8 @@ struct _report_error
 
         std::size_t finish() &&
         {
-            std::fputs("\n", stderr);
+            if (_count != 0)
+                std::fputs("\n", stderr);
             return _count;
         }
     };


### PR DESCRIPTION
It's mildly annoying to have successful parsing produce output to stderr.