### PR TITLE
Pass operator() through to bound sinks

### DIFF
--- a/docs/content/reference/callback/bind.adoc
+++ b/docs/content/reference/callback/bind.adoc
@@ -162,6 +162,7 @@ A call to `bound.sink()` results in a call to `sink.sink(args...)`, where no arg
 A call to `bound.sink(context)` results in a call to `sink.sink()` with the expanded arguments:
 If the argument is a placeholder, it is expanded as described there but note that there are no values, only a context parameter.
 Otherwise, the bound argument is forwarded as-is.
+Calls to `bound(...)` will be forwarded as-is onto `sink(...)`, allowing a bound sink to be used with rules like opt_list from {{% docref "lexy::dsl::terminator" %}}.
 
 {{% godbolt-example "bind_sink-parse_state" "Construct the list of integers with a custom allocator" %}}
 

--- a/include/lexy/callback/bind.hpp
+++ b/include/lexy/callback/bind.hpp
@@ -8,6 +8,8 @@
 #include <lexy/_detail/tuple.hpp>
 #include <lexy/callback/base.hpp>
 
+#include <type_traits>
+
 //=== placeholder details ===//
 namespace lexy::_detail
 {
@@ -347,13 +349,14 @@ struct _bound_sink
     LEXY_EMPTY_MEMBER Sink _sink;
     LEXY_EMPTY_MEMBER _detail::tuple<BoundArgs...> _bound;
 
-    /*
-        constexpr auto sink() const
-        {
-            return _detail::invoke_bound(_sink_wrapper<Sink>{_sink}, _bound,
-       _bound.index_sequence(), _detail::no_bind_context{});
-        }
-        */
+    template <bool Dummy = true,
+              typename   = std::enable_if_t<(!_detail::is_placeholder<BoundArgs> && ... && Dummy)>>
+    constexpr auto sink() const
+    {
+        return _detail::invoke_bound(_sink_wrapper<Sink>{_sink}, _bound, _bound.index_sequence(),
+                                     _detail::no_bind_context{});
+    }
+
     template <typename Context>
     constexpr auto sink(const Context& context) const
     {
@@ -377,4 +380,3 @@ constexpr auto bind_sink(Sink&& sink, BoundArgs&&... args)
 } // namespace lexy
 
 #endif // LEXY_CALLBACK_BIND_HPP_INCLUDED
-

--- a/include/lexy/callback/bind.hpp
+++ b/include/lexy/callback/bind.hpp
@@ -349,6 +349,12 @@ struct _bound_sink
     LEXY_EMPTY_MEMBER Sink _sink;
     LEXY_EMPTY_MEMBER _detail::tuple<BoundArgs...> _bound;
 
+    template <typename... Args>
+    constexpr auto operator()(Args... args) const -> decltype(_sink(LEXY_FWD(args)...))
+    {
+        return _sink(LEXY_FWD(args)...);
+    }
+
     template <bool Dummy = true,
               typename   = std::enable_if_t<(!_detail::is_placeholder<BoundArgs> && ... && Dummy)>>
     constexpr auto sink() const

--- a/tests/lexy/callback/bind.cpp
+++ b/tests/lexy/callback/bind.cpp
@@ -125,4 +125,36 @@ TEST_CASE("bind_sink")
         cb(42);
         CHECK(LEXY_MOV(cb).finish() == 2 * 11 + 3 + 2 * 42 + 3);
     }
+
+    SUBCASE("bound passes nullopt to underlying sink")
+    {
+        constexpr auto const expected = 12345;
+
+        struct sink_handles_nullopt
+        {
+            struct dummy_impl
+            {
+                void operator()(int) {}
+
+                auto finish() && -> int
+                {
+                    return 7;
+                }
+            };
+
+            constexpr auto operator()(lexy::nullopt&&) const
+            {
+                return expected;
+            }
+
+            constexpr auto sink(int)
+            {
+                return dummy_impl{};
+            }
+        };
+
+        constexpr auto bound = lexy::bind_sink(sink_handles_nullopt{}, 15);
+
+        CHECK(bound(lexy::nullopt{}) == expected);
+    }
 }

--- a/tests/lexy/callback/bind.cpp
+++ b/tests/lexy/callback/bind.cpp
@@ -106,11 +106,23 @@ TEST_CASE("bind_sink")
         }
     };
 
-    constexpr auto bound = lexy::bind_sink(my_sink{}, lexy::parse_state, 3.14f);
+    SUBCASE("bound with context")
+    {
+        constexpr auto bound = lexy::bind_sink(my_sink{}, lexy::parse_state, 3.14f);
 
-    auto cb = bound.sink(2);
-    cb(11);
-    cb(42);
-    CHECK(LEXY_MOV(cb).finish() == 2 * 11 + 3 + 2 * 42 + 3);
+        auto cb = bound.sink(2);
+        cb(11);
+        cb(42);
+        CHECK(LEXY_MOV(cb).finish() == 2 * 11 + 3 + 2 * 42 + 3);
+    }
+
+    SUBCASE("bound without context")
+    {
+        constexpr auto bound = lexy::bind_sink(my_sink{}, 2, 3.14f);
+
+        auto cb = bound.sink();
+        cb(11);
+        cb(42);
+        CHECK(LEXY_MOV(cb).finish() == 2 * 11 + 3 + 2 * 42 + 3);
+    }
 }
-


### PR DESCRIPTION
I believe this addresses #32, I've opted for a simpler approach to begin with that simply forwards all calls to the bound sink - regardless of if it has the appropriate operator. This will fail to compile in a similar way to as if the sink were used directly. These template member functions could use enable_if to enable/disable them appropriately but I'm not sure that would lead to better error messages!

I wasn't able to get the docs to build locally, hopefully what I've changed works/makes sense