### PR TITLE
Fix multiple build issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     option(LEXY_BUILD_EXAMPLES   "whether or not examples should be built" ON)
     option(LEXY_BUILD_TESTS      "whether or not tests should be built" ON)
     option(LEXY_BUILD_DOCS       "whether or not docs should be built" OFF)
-	option(LEXY_BUILD_PACKAGE    "whether or not the package should be built" OFF)
+	option(LEXY_BUILD_PACKAGE    "whether or not the package should be built" ON)
 
 	if(LEXY_BUILD_PACKAGE)
         set(package_files include/ src/ CMakeLists.txt LICENSE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,13 +15,16 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     option(LEXY_BUILD_EXAMPLES   "whether or not examples should be built" ON)
     option(LEXY_BUILD_TESTS      "whether or not tests should be built" ON)
     option(LEXY_BUILD_DOCS       "whether or not docs should be built" OFF)
+	option(LEXY_BUILD_PACKAGE    "whether or not the package should be built" OFF)
 
-    set(package_files include/ src/ CMakeLists.txt LICENSE)
-    add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip
-        COMMAND ${CMAKE_COMMAND} -E tar c ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip --format=zip -- ${package_files}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        DEPENDS ${package_files})
-    add_custom_target(lexy_package DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip)
+	if(LEXY_BUILD_PACKAGE)
+        set(package_files include/ src/ CMakeLists.txt LICENSE)
+        add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip
+            COMMAND ${CMAKE_COMMAND} -E tar c ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip --format=zip -- ${package_files}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            DEPENDS ${package_files})
+        add_custom_target(lexy_package DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip)
+    endif()
 
     if(LEXY_BUILD_EXAMPLES)
         add_subdirectory(examples)

--- a/examples/calculator.cpp
+++ b/examples/calculator.cpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <utility>
 
 #include <lexy/callback.hpp>
 #include <lexy/dsl.hpp>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,7 +4,7 @@
 # Fetch doctest.
 message(STATUS "Fetching doctest")
 include(FetchContent)
-FetchContent_Declare(doctest URL https://github.com/onqtam/doctest/archive/2.4.5.zip)
+FetchContent_Declare(doctest URL https://github.com/onqtam/doctest/archive/2.4.6.zip)
 FetchContent_MakeAvailable(doctest)
 
 # A generic test target.


### PR DESCRIPTION
This PR fixes multiple issues in different stages of compilation. I detected these because suddenly one of my projects that uses lexy stopped working.

The first commit enables conditional creation of the package zip file. This is needed by me personally because meson and its CMake submodule sadly do not work with the custom command.

The second commit fixes a missing include in the calculator example.

The third commit fixes a compilation issue that was fixed in the next doctest version. I tried to use 2.4.8 but it was not available, and 2.4.7 also had compilation errors.