### PR TITLE
Add cmake install target #26

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,10 @@ project(lexy VERSION 2022.05.0 LANGUAGES CXX)
 set(LEXY_USER_CONFIG_HEADER "" CACHE FILEPATH "The user config header for lexy.")
 option(LEXY_FORCE_CPP17     "Whether or not lexy should use C++17 even if compiler supports C++20." OFF)
 
+list(APPEND CMAKE_MODULE_PATH
+    ${CMAKE_CURRENT_LIST_DIR}/cmake
+)
+
 add_subdirectory(src)
 
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
@@ -16,6 +20,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     option(LEXY_BUILD_TESTS      "whether or not tests should be built" ON)
     option(LEXY_BUILD_DOCS       "whether or not docs should be built" OFF)
     option(LEXY_BUILD_PACKAGE    "whether or not the package should be built" ON)
+    option(LEXY_ENABLE_INSTALL   "whether or not to enable the install rule" ON)
 
     if(LEXY_BUILD_PACKAGE)
         set(package_files include/ src/ CMakeLists.txt LICENSE)
@@ -33,6 +38,7 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
         add_subdirectory(benchmarks)
     endif()
     if(LEXY_BUILD_TESTS)
+        set(DOCTEST_NO_INSTALL ON)
         enable_testing()
         add_subdirectory(tests)
     endif()
@@ -41,3 +47,49 @@ if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     endif()
 endif()
 
+if(LEXY_ENABLE_INSTALL)
+
+    include(CMakePackageConfigHelpers)
+    include(GNUInstallDirs)
+
+    install(TARGETS lexy_core lexy_file lexy_unicode lexy_ext _lexy_base lexy_dev
+        EXPORT ${PROJECT_NAME}Targets
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+
+    # install as a subdirectory only
+    install(EXPORT ${PROJECT_NAME}Targets
+        NAMESPACE foonathan::
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    )
+
+    configure_package_config_file(
+        cmake/lexyConfig.cmake.in
+        "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    )
+    install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    )
+
+    write_basic_package_version_file(
+      "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+      COMPATIBILITY AnyNewerVersion
+    )
+
+    install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+      DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}"
+    )
+
+    install(
+        DIRECTORY 
+            include/lexy 
+            include/lexy_ext
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+        FILES_MATCHING
+          PATTERN "*.hpp"
+    )
+
+endif() # LEXY_ENABLE_INSTALL

--- a/cmake/lexyConfig.cmake.in
+++ b/cmake/lexyConfig.cmake.in
@@ -1,0 +1,5 @@
+# lexy CMake configuration file.
+
+@PACKAGE_INIT@
+
+include ("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -148,13 +148,19 @@ endif()
 add_library(lexy_core INTERFACE)
 add_library(foonathan::lexy::core ALIAS lexy_core)
 target_link_libraries(lexy_core INTERFACE _lexy_base)
-target_include_directories(lexy_core SYSTEM INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_include_directories(lexy_core SYSTEM INTERFACE 
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>    
+    )
 
 # Core library with warnings; for development only.
 add_library(lexy_dev INTERFACE)
 add_library(foonathan::lexy::dev ALIAS lexy_dev)
 target_link_libraries(lexy_dev INTERFACE _lexy_base)
-target_include_directories(lexy_dev INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/../include)
+target_include_directories(lexy_dev INTERFACE 
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>    
+    )
 
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
     if("${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC")
@@ -173,11 +179,11 @@ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
     # GCC's arry bounds, maybe uninitialized, and restrict warning seems to have false positives.
     target_compile_options(lexy_dev INTERFACE -Wno-array-bounds -Wno-maybe-uninitialized -Wno-restrict)
 elseif(MSVC)
-    target_compile_options(lexy_dev INTERFACE /WX /W3 /D _CRT_SECURE_NO_WARNINGS /wd5105)
+    target_compile_options(lexy_dev INTERFACE /WX /W3 /EHsc /D _CRT_SECURE_NO_WARNINGS /wd5105)
 endif()
 
-# Link to have FILE I/O.
-add_library(lexy_file)
+# Link to have FILE I/O. 
+add_library(lexy_file STATIC)
 add_library(foonathan::lexy::file ALIAS lexy_file)
 target_link_libraries(lexy_file PRIVATE foonathan::lexy::dev)
 target_sources(lexy_file PRIVATE input/file.cpp)


### PR DESCRIPTION
This adds the cmake install targets boilerplate so you can run `ninja/make install`. 
It enables to add lexy to vcpkg registry, attached are the 2 files that can be added to vcpkg/ports/lexy (commit and hash must still be updated in portfile.cmake)
[lexy.zip](https://github.com/foonathan/lexy/files/9078611/lexy.zip)
