### PR TITLE
Construct operator tags with state

### DIFF
--- a/docs/content/reference/dsl/operator.adoc
+++ b/docs/content/reference/dsl/operator.adoc
@@ -47,6 +47,7 @@ Values::
   * For overload 1, a unique type computed from the rule `r`.
   * For overload 2 and `Tag != void`, an object of the specified `Tag` type.
     If `Tag` is constructible from the iterator type of the input, it constructs it giving it the start position of the operator.
+    Similarly, it is also possible to construct the `Tag` from the parse state and the iterator.
     Otherwise, it uses the default constructor.
   * For overload 2 and `Tag == void`, no tag value is produced.
   * For overload 3, an object of implementation-defined type that is implicitly convertible to the type of `Tag`, returning that value.

--- a/tests/lexy/CMakeLists.txt
+++ b/tests/lexy/CMakeLists.txt
@@ -75,6 +75,7 @@ set(tests
         dsl/member.cpp
         dsl/newline.cpp
         dsl/operator.cpp
+        dsl/operator_state.cpp
         dsl/option.cpp
         dsl/parse_as.cpp
         dsl/peek.cpp

--- a/tests/lexy/dsl/operator_state.cpp
+++ b/tests/lexy/dsl/operator_state.cpp
@@ -1,0 +1,88 @@
+// Copyright (C) 2020-2023 Jonathan Müller and lexy contributors
+// SPDX-License-Identifier: BSL-1.0
+
+#include <lexy/dsl/operator.hpp>
+
+#include <doctest/doctest.h>
+#include <lexy/action/parse.hpp>
+#include <lexy/callback.hpp>
+#include <lexy/dsl/expression.hpp>
+#include <lexy/dsl/sequence.hpp>
+#include <lexy/input/string_input.hpp>
+
+namespace
+{
+
+namespace dsl = lexy::dsl;
+
+struct state
+{
+    char const*    begin;
+    std::ptrdiff_t diff;
+};
+
+struct tag
+{
+    constexpr tag(state& st, char const* it)
+    {
+        st.diff = it - st.begin;
+    }
+};
+
+struct test_finish : lexy::expression_production
+{
+    static constexpr auto atom = LEXY_LIT("x");
+
+    struct operation : dsl::prefix_op
+    {
+        static constexpr auto op = dsl::op<tag>(LEXY_LIT("-"));
+        using operand            = dsl::atom;
+    };
+
+    static constexpr auto value = lexy::noop;
+};
+
+struct test_bp
+{
+    static constexpr auto rule  = dsl::op<tag>(LEXY_LIT("-")) | dsl::op<tag>(LEXY_LIT("+"));
+    static constexpr auto value = lexy::forward<tag>;
+};
+
+struct test_p
+{
+    static constexpr auto rule  = dsl::op<tag>(LEXY_LIT("-"));
+    static constexpr auto value = lexy::forward<tag>;
+};
+
+} // namespace
+
+TEST_CASE("dsl::op_state")
+{
+    SUBCASE("finish")
+    {
+        auto const* str   = "-x";
+        auto        input = lexy::zstring_input(str);
+        auto        st    = state{input.reader().position(), -1};
+        auto        ret   = lexy::parse<test_finish>(input, st, lexy::noop);
+        CHECK(ret.is_success());
+        CHECK(st.diff == 0);
+    }
+    SUBCASE("bp")
+    {
+        auto const* str   = "-";
+        auto        input = lexy::zstring_input(str);
+        auto        st    = state{input.reader().position(), -1};
+        auto        ret   = lexy::parse<test_bp>(input, st, lexy::noop);
+        CHECK(ret.is_success());
+        CHECK(st.diff == 0);
+    }
+    SUBCASE("p")
+    {
+        auto const* str   = "-";
+        auto        input = lexy::zstring_input(str);
+        auto        st    = state{input.reader().position(), -1};
+        auto        ret   = lexy::parse<test_p>(input, st, lexy::noop);
+        CHECK(ret.is_success());
+        CHECK(st.diff == 0);
+    }
+}


### PR DESCRIPTION
Optionally, support constructing operator tags from the parse state and an input iterator.

## Notes

- I did not know how to add a state into the verify construction of the exiting operator tests so I simply added tests separately. 
- Maybe you have a better idea how to test this? It would be quite hard for me to dive into the details here.
- See also #170.