### PR TITLE
Fix MSVC errors

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -191,7 +191,7 @@ elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
     # GCC's arry bounds, maybe uninitialized, and restrict warning seems to have false positives.
     target_compile_options(lexy_dev INTERFACE -Wno-array-bounds -Wno-maybe-uninitialized -Wno-restrict)
 elseif(MSVC)
-    target_compile_options(lexy_dev INTERFACE /WX /W3 /D _CRT_SECURE_NO_WARNINGS /wd5105)
+    target_compile_options(lexy_dev INTERFACE /WX /W3 /D _CRT_SECURE_NO_WARNINGS /wd5105 /utf-8)
 endif()
 
 # Link to have FILE I/O.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,6 @@ target_compile_definitions(lexy_test_base PUBLIC LEXY_TEST)
 if(MSVC AND NOT ${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
     target_compile_options(lexy_test_base PUBLIC
         /Zc:preprocessor    # need a conforming preprocessor for stringifying escape characters
-        "/utf-8"            # use utf-8 instead of current code page
         /bigobj             # some of the object files are really big for some reason
     )
 endif()

--- a/tests/lexy/detail/string_view.cpp
+++ b/tests/lexy/detail/string_view.cpp
@@ -39,7 +39,7 @@ constexpr auto fn()
 
 TEST_CASE("make_cstr")
 {
-    constexpr auto str = lexy::_detail::make_cstr<+fn>;
+    constexpr auto str = lexy::_detail::make_cstr<&fn>;
     REQUIRE(str == lexy::_detail::string_view("ab"));
 }
 


### PR DESCRIPTION
I made several changes to your library. I hope these changes improve your code.

The reasons of the 2nd commit about /utf-8 and /EHsc are
- Because compiling lexy with MSVC requires utf-8, it is natural to add /utf-8 option to lexy_dev itself.
- When opening the root directory with Visual Studio, VS does not automatically add /EHsc option, leading to a compilation error. (This does not occur when using VSCode.)