### PR TITLE
Adding case for void state to production_value_callback

### DIFF
--- a/include/lexy/grammar.hpp
+++ b/include/lexy/grammar.hpp
@@ -340,7 +340,8 @@ public:
     template <typename... Args>
     constexpr return_type operator()(Args&&... args) const
     {
-        if constexpr (lexy::is_callback_with_state_for<_type, ParseState, Args&&...>)
+        if constexpr (lexy::is_callback_with_state_for<_type, ParseState, Args&&...>
+                      && !std::is_void_v<ParseState>)
         {
             return _get_value(_state)[*_state](LEXY_FWD(args)...);
         }


### PR DESCRIPTION
We've had a problem where a void state would still trigger the first if-branch in this internal parsing function. Adding an is_void_v check fixes our problem, I don't know if that breaks any other expected function (that we don't use)