### PR TITLE
Fix IP address printing: 4 hex digits per piece

### DIFF
--- a/examples/ip_address.cpp
+++ b/examples/ip_address.cpp
@@ -252,7 +252,7 @@ int main(int argc, char* argv[])
     std::printf("0x");
     auto count = value.version == 4 ? 2 : 8;
     for (auto i = 0; i < count; ++i)
-        std::printf("%02X", value.pieces[i]);
+        std::printf("%04X", value.pieces[i]);
     std::printf("\n");
 
     return result ? 0 : 1;


### PR DESCRIPTION
Fixes a printing mistake: pieces are uint16, not uint8.

Before:

```
$ ./ip_address 1.1.1.1
0x101101
$ ./ip_address ::1
0x0000000000000001
$ ./ip_address 2a00:1450:400a:808::200e
0x2A001450400A808000000200E
```

After:

```
$ ./ip_address 1.1.1.1
0x01010101
$ ./ip_address ::1
0x00000000000000000000000000000001
$ ./ip_address 2a00:1450:400a:808::200e
0x2A001450400A0808000000000000200E
```
