### PR TITLE
<bit> produces warning when building with C++17

### DIFF
--- a/include/lexy/callback/bit_cast.hpp
+++ b/include/lexy/callback/bit_cast.hpp
@@ -16,7 +16,7 @@
 
 #ifndef LEXY_HAS_BITCAST
 #    if defined(__has_include)
-#        if __has_include(<bit>)
+#        if __has_include(<bit>) && __cplusplus >= 202002L
 #            include <bit>
 #            ifdef __cpp_lib_bit_cast
 #                define LEXY_HAS_BITCAST 1


### PR DESCRIPTION
`<bit>` produces warning when building with C++17:
`The contents of <bit> are available only with C++20 or later.`

`bit_cast.hpp` checks for `__has_includes()` but it needs to also check `__cplusplus >= 202002L`