### PR TITLE
Fix Clang/MSVC compile options handling

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -177,10 +177,13 @@ target_include_directories(lexy_dev INTERFACE
     )
 
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
-    if("${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC")
+    if("${CMAKE_CXX_COMPILER_FRONTEND_VARIANT}" STREQUAL "MSVC")
         target_compile_options(lexy_dev INTERFACE /WX /W3 /D _CRT_SECURE_NO_WARNINGS)
     else()
         target_compile_options(lexy_dev INTERFACE -pedantic-errors -Werror -Wall -Wextra -Wconversion -Wsign-conversion)
+        if("${CMAKE_CXX_SIMULATE_ID}" STREQUAL "MSVC")
+            target_compile_options(lexy_dev INTERFACE -D_CRT_SECURE_NO_WARNINGS)
+        endif()
     endif()
     # clang doesn't like operator precedence rules we're using for the DSL.
     target_compile_options(lexy_dev INTERFACE -Wno-shift-op-parentheses -Wno-parentheses-equality)


### PR DESCRIPTION
I noticed an issue with Lexy where it will fail to build on Windows using Clang with the GNU-like command-line.

```powershell
PS C:\Users\User\Documents\lexy> $env:CXX = 'C:\Program Files\LLVM\bin\clang++.exe'
PS C:\Users\User\Documents\lexy> cmake -G Ninja -B build
-- The CXX compiler identification is Clang 18.1.8 with GNU-like command-line
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: C:/Program Files/LLVM/bin/clang++.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Fetching doctest
CMake Deprecation Warning at build/_deps/doctest-src/CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Configuring done (3.3s)
-- Generating done (0.2s)
-- Build files have been written to: C:/Users/User/Documents/lexy/build
PS C:\Users\User\Documents\lexy> cmake --build .\build\
[0/2] Re-checking globbed directories...
[1/398] Building CXX object tests/CMakeFiles/lexy_test_base.dir/doctest_main.cpp.obj
FAILED: tests/CMakeFiles/lexy_test_base.dir/doctest_main.cpp.obj
C:\PROGRA~1\LLVM\bin\CLANG_~1.EXE -DLEXY_HAS_UNICODE_DATABASE=1 -DLEXY_TEST -IC:/Users/User/Documents/lexy/src/../include -IC:/Users/User/Documents/lexy/build/_deps/doctest-src -O0 -g -Xclang -gcodeview -D_DEBUG -D_DLL -D_MT -Xclang --dependent-lib=msvcrtd -std=gnu++20 /WX /W3 /D _CRT_SECURE_NO_WARNINGS -Wno-shift-op-parentheses -Wno-parentheses-equality -MD -MT tests/CMakeFiles/lexy_test_base.dir/doctest_main.cpp.obj -MF tests\CMakeFiles\lexy_test_base.dir\doctest_main.cpp.obj.d -o tests/CMakeFiles/lexy_test_base.dir/doctest_main.cpp.obj -c C:/Users/User/Documents/lexy/tests/doctest_main.cpp
clang++: error: no such file or directory: '/WX'
clang++: error: no such file or directory: '/W3'
clang++: error: no such file or directory: '/D'
clang++: error: no such file or directory: '_CRT_SECURE_NO_WARNINGS'
[2/398] Building CXX object src/CMakeFiles/lexy_file.dir/input/file.cpp.obj
```

This is due to the [src/CMakeLists.txt#L180](https://github.com/foonathan/lexy/blob/1e5d99fa3826b1c3c8628d3a11117fb4fb4cc0d0/src/CMakeLists.txt#L180) using [CMAKE_CXX_SIMULATE_ID](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_SIMULATE_ID.html) for checking what compile options to add which does not reflect how the command line options are handled.

The [CMAKE_CXX_COMPILER_FRONTEND_VARIANT](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_COMPILER_FRONTEND_VARIANT.html) variable has the correct information for determining this.

More information on detecting the differences between `clang` with the GNU-like command-line and `clang-cl` with the MSVC-like command-line can be found in this CMake issue https://gitlab.kitware.com/cmake/cmake/-/issues/19724. It looks like these variables were undocumented for a while and only recently added to the CMake documentation.

The changes in this PR should correctly handle Lexy being built using `clang` or `clang-cl` on Windows.