### PR TITLE
Fix x86 build on Visual Studio (C++ 20 only)

### DIFF
--- a/.github/workflows/feature_ci.yml
+++ b/.github/workflows/feature_ci.yml
@@ -60,7 +60,12 @@ jobs:
       run: ctest --output-on-failure
 
   windows:
-    runs-on: windows-2019
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [Win32, x64]
+
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2
@@ -70,7 +75,7 @@ jobs:
     - name: Configure
       shell: bash
       working-directory: build/
-      run: cmake $GITHUB_WORKSPACE -G"Visual Studio 16 2019"
+      run: cmake $GITHUB_WORKSPACE -G"Visual Studio 17 2022" -A ${{matrix.arch}}
     - name: Build
       working-directory: build/
       run: cmake --build . --config Debug -j 2

--- a/.github/workflows/main_ci.yml
+++ b/.github/workflows/main_ci.yml
@@ -81,10 +81,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        toolset: ['v142', 'ClangCL']
+        toolset: ['v142', 'v143', 'ClangCL']
         build_type: [Debug, Release]
+        arch: [Win32, x64]
 
-    runs-on: windows-2019
+    runs-on: windows-2022
 
     steps:
     - uses: actions/checkout@v2
@@ -94,7 +95,7 @@ jobs:
     - name: Configure
       shell: bash
       working-directory: build/
-      run: cmake $GITHUB_WORKSPACE -G"Visual Studio 16 2019" -T ${{matrix.toolset}}
+      run: cmake $GITHUB_WORKSPACE -G"Visual Studio 17 2022" -T ${{matrix.toolset}} -A ${{matrix.arch}}
     - name: Build
       working-directory: build/
       run: cmake --build . --config ${{matrix.build_type}} -j 2

--- a/include/lexy/_detail/swar.hpp
+++ b/include/lexy/_detail/swar.hpp
@@ -4,6 +4,9 @@
 #ifndef LEXY_DETAIL_SWAR_HPP_INCLUDED
 #define LEXY_DETAIL_SWAR_HPP_INCLUDED
 
+#if defined(_MSC_VER) && _MSVC_LANG >= 202002L
+#    include <bit>
+#endif
 #include <climits>
 #include <cstdint>
 #include <cstring>
@@ -139,10 +142,12 @@ constexpr std::size_t swar_find_difference(swar_int lhs, swar_int rhs)
 
 #if defined(__GNUC__)
     auto bit_idx = __builtin_ctzll(mask);
-#elif defined(_MSC_VER)
+#elif defined(_MSC_VER) && _MSVC_LANG >= 202002L
+    auto bit_idx = std::countr_zero(mask);
+#elif defined(_MSC_VER) && defined(_WIN64)
     unsigned long bit_idx;
     if (!_BitScanForward64(&bit_idx, mask))
-        bit_idx         = 64;
+        bit_idx = 64;
 #else
 #    error "unsupported compiler; please file an issue"
 #endif

--- a/include/lexy/parse_tree.hpp
+++ b/include/lexy/parse_tree.hpp
@@ -132,7 +132,7 @@ struct pt_node_token : pt_node<Reader>
         if constexpr (_optimize_end)
         {
             static_assert(!std::is_pointer_v<typename Reader::iterator>
-                          || sizeof(pt_node_token) == 3 * sizeof(void*));
+                          || sizeof(pt_node_token) == 2 * sizeof(void*) + 8);
 
             auto size = std::size_t(end - begin);
             LEXY_PRECONDITION(size <= UINT_LEAST32_MAX);


### PR DESCRIPTION
Hi,

I noticed that 32-bit builds with Visual Studio failed due to the use of `_BitScanForward64()`, which is only available in 64-bit builds.

This tweaks things so that `std::countr_zero()` is used for Visual Studio when C++ 20 or newer is targetted. That fixes things for 32-bit builds in VS when C++ 20 is used, but 32-bit VS builds targetting C++ 17 remain unsupported.

This fix is good enough for me, though I imagine you'd want to tweak things a bit (write access is enabled on the head branch).
