### PR TITLE
feat: initial integration for fuzzing

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,100 +4,89 @@
 cmake_minimum_required(VERSION 3.8)
 project(lexy VERSION 2022.12.1 LANGUAGES CXX)
 
+# Core options
 set(LEXY_USER_CONFIG_HEADER "" CACHE FILEPATH "The user config header for lexy.")
-option(LEXY_FORCE_CPP17     "Whether or not lexy should use C++17 even if compiler supports C++20." OFF)
-option(LEXY_BUILD_FUZZERS "whether or not fuzzers should be built" OFF)
-option(LEXY_BUILD_FUZZERS_AFLPLUSPLUS "Use AFL++ instead of libFuzzer" OFF)
-option(FORCE_STATIC_LINKING "Force static linking for fuzzing targets" OFF)
+option(LEXY_FORCE_CPP17 "Whether or not lexy should use C++17 even if compiler supports C++20." OFF)
 
-if(LEXY_BUILD_FUZZERS)
-    execute_process(
-        COMMAND ${CMAKE_CXX_COMPILER} --version
-        OUTPUT_VARIABLE CXX_COMPILER_VERSION
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-    )
-    if(NOT CXX_COMPILER_VERSION MATCHES "clang")
-        message(FATAL_ERROR "Fuzzing requires a Clang-based compiler")
+# Include the fuzzing module
+include(cmake/Fuzzing.cmake)
+
+# Always add the source library
+add_subdirectory(src)
+
+# Setup fuzzing if enabled
+setup_fuzzing_environment()
+
+# If we're the main project (not included as a subproject), set up additional components
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR AND NOT LEXY_BUILD_FUZZERS)
+    cmake_minimum_required(VERSION 3.18)
+
+    # Optional components
+    option(LEXY_BUILD_BENCHMARKS "whether or not benchmarks should be built" OFF)
+    option(LEXY_BUILD_EXAMPLES   "whether or not examples should be built" ON)
+    option(LEXY_BUILD_TESTS      "whether or not tests should be built" ON)
+    option(LEXY_BUILD_DOCS       "whether or not docs should be built" OFF)
+    option(LEXY_BUILD_PACKAGE    "whether or not the package should be built" ON)
+    option(LEXY_ENABLE_INSTALL   "whether or not to enable the install rule" ON)
+
+    # Build optional components
+    if(LEXY_BUILD_EXAMPLES)
+        add_subdirectory(examples)
+    endif()
+    if(LEXY_BUILD_BENCHMARKS)
+        add_subdirectory(benchmarks)
+    endif()
+    if(LEXY_BUILD_TESTS)
+        set(DOCTEST_NO_INSTALL ON)
+        enable_testing()
+        add_subdirectory(tests)
+    endif()
+    if(LEXY_BUILD_DOCS)
+        add_subdirectory(docs EXCLUDE_FROM_ALL)
     endif()
 
-    if(CMAKE_C_COMPILER MATCHES ".*afl-.*" OR CMAKE_CXX_COMPILER MATCHES ".*afl-.*")
-        set(LEXY_BUILD_FUZZERS_AFLPLUSPLUS ON CACHE BOOL "Use AFL++ instead of libFuzzer" FORCE)
-        message(STATUS "AFL++ compiler detected - automatically enabling AFL++ mode")
+    # Package creation
+    if(LEXY_BUILD_PACKAGE)
+        set(package_files include/ src/ cmake/ CMakeLists.txt LICENSE)
+        add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip
+            COMMAND ${CMAKE_COMMAND} -E tar c ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip --format=zip -- ${package_files}
+            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+            DEPENDS ${package_files})
+        add_custom_target(lexy_package DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip)
     endif()
 
-    add_subdirectory(src)
-    add_subdirectory(fuzzers)
-else()
-    add_subdirectory(src)
+    # Installation configuration
+    if(LEXY_ENABLE_INSTALL)
+        include(CMakePackageConfigHelpers)
+        include(GNUInstallDirs)
 
-    if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-        cmake_minimum_required(VERSION 3.18)
-        option(LEXY_BUILD_BENCHMARKS "whether or not benchmarks should be built" OFF)
-        option(LEXY_BUILD_EXAMPLES   "whether or not examples should be built" ON)
-        option(LEXY_BUILD_TESTS      "whether or not tests should be built" ON)
-        option(LEXY_BUILD_DOCS       "whether or not docs should be built" OFF)
-        option(LEXY_BUILD_PACKAGE    "whether or not the package should be built" ON)
-        option(LEXY_ENABLE_INSTALL   "whether or not to enable the install rule" ON)
+        install(TARGETS lexy lexy_core lexy_file lexy_unicode lexy_ext _lexy_base lexy_dev
+            EXPORT ${PROJECT_NAME}Targets
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+            LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
 
-        # Optional components
-        if(LEXY_BUILD_EXAMPLES)
-            add_subdirectory(examples)
-        endif()
-        if(LEXY_BUILD_BENCHMARKS)
-            add_subdirectory(benchmarks)
-        endif()
-        if(LEXY_BUILD_TESTS)
-            set(DOCTEST_NO_INSTALL ON)
-            enable_testing()
-            add_subdirectory(tests)
-        endif()
-        if(LEXY_BUILD_DOCS)
-            add_subdirectory(docs EXCLUDE_FROM_ALL)
-        endif()
+        install(EXPORT ${PROJECT_NAME}Targets
+            NAMESPACE foonathan::
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
-        # Package creation
-        if(LEXY_BUILD_PACKAGE)
-            set(package_files include/ src/ cmake/ CMakeLists.txt LICENSE)
-            add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip
-                COMMAND ${CMAKE_COMMAND} -E tar c ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip --format=zip -- ${package_files}
-                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-                DEPENDS ${package_files})
-            add_custom_target(lexy_package DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip)
-        endif()
+        configure_package_config_file(
+            cmake/lexyConfig.cmake.in
+            "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+            INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+        install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
-        # Installation configuration
-        if(LEXY_ENABLE_INSTALL)
-            include(CMakePackageConfigHelpers)
-            include(GNUInstallDirs)
+        write_basic_package_version_file(
+            "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+            COMPATIBILITY SameMinorVersion)
 
-            install(TARGETS lexy lexy_core lexy_file lexy_unicode lexy_ext _lexy_base lexy_dev
-                EXPORT ${PROJECT_NAME}Targets
-                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+            DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
 
-            install(EXPORT ${PROJECT_NAME}Targets
-                NAMESPACE foonathan::
-                DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-
-            configure_package_config_file(
-                cmake/lexyConfig.cmake.in
-                "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-                INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-            install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-                DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-
-            write_basic_package_version_file(
-                "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-                COMPATIBILITY SameMinorVersion)
-
-            install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-                DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-
-            install(DIRECTORY include/lexy include/lexy_ext
-                DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-                FILES_MATCHING
-                PATTERN "*.hpp")
-        endif()
+        install(DIRECTORY include/lexy include/lexy_ext
+            DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+            FILES_MATCHING
+            PATTERN "*.hpp")
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,74 +6,98 @@ project(lexy VERSION 2022.12.1 LANGUAGES CXX)
 
 set(LEXY_USER_CONFIG_HEADER "" CACHE FILEPATH "The user config header for lexy.")
 option(LEXY_FORCE_CPP17     "Whether or not lexy should use C++17 even if compiler supports C++20." OFF)
+option(LEXY_BUILD_FUZZERS "whether or not fuzzers should be built" OFF)
+option(LEXY_BUILD_FUZZERS_AFLPLUSPLUS "Use AFL++ instead of libFuzzer" OFF)
+option(FORCE_STATIC_LINKING "Force static linking for fuzzing targets" OFF)
 
-add_subdirectory(src)
-
-option(LEXY_ENABLE_INSTALL   "whether or not to enable the install rule" ON)
-if(LEXY_ENABLE_INSTALL)
-    include(CMakePackageConfigHelpers)
-    include(GNUInstallDirs)
-
-    install(TARGETS lexy lexy_core lexy_file lexy_unicode lexy_ext _lexy_base lexy_dev
-        EXPORT ${PROJECT_NAME}Targets
-        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-        LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
-
-    install(EXPORT ${PROJECT_NAME}Targets
-        NAMESPACE foonathan::
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-
-    configure_package_config_file(
-        cmake/lexyConfig.cmake.in
-        "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-        INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-    install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-
-    # YYYY.MM.N1 is compatible with YYYY.MM.N2.
-    write_basic_package_version_file(
-        "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-        COMPATIBILITY SameMinorVersion)
-
-    install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
-
-    install(DIRECTORY include/lexy include/lexy_ext
-        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
-        FILES_MATCHING
-        PATTERN "*.hpp")
-endif()
-
-if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-    cmake_minimum_required(VERSION 3.18)
-    option(LEXY_BUILD_BENCHMARKS "whether or not benchmarks should be built" OFF)
-    option(LEXY_BUILD_EXAMPLES   "whether or not examples should be built" ON)
-    option(LEXY_BUILD_TESTS      "whether or not tests should be built" ON)
-    option(LEXY_BUILD_DOCS       "whether or not docs should be built" OFF)
-    option(LEXY_BUILD_PACKAGE    "whether or not the package should be built" ON)
-
-    if(LEXY_BUILD_PACKAGE)
-        set(package_files include/ src/ cmake/ CMakeLists.txt LICENSE)
-        add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip
-            COMMAND ${CMAKE_COMMAND} -E tar c ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip --format=zip -- ${package_files}
-            WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-            DEPENDS ${package_files})
-        add_custom_target(lexy_package DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip)
+if(LEXY_BUILD_FUZZERS)
+    execute_process(
+        COMMAND ${CMAKE_CXX_COMPILER} --version
+        OUTPUT_VARIABLE CXX_COMPILER_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if(NOT CXX_COMPILER_VERSION MATCHES "clang")
+        message(FATAL_ERROR "Fuzzing requires a Clang-based compiler")
     endif()
 
-    if(LEXY_BUILD_EXAMPLES)
-        add_subdirectory(examples)
+    if(CMAKE_C_COMPILER MATCHES ".*afl-.*" OR CMAKE_CXX_COMPILER MATCHES ".*afl-.*")
+        set(LEXY_BUILD_FUZZERS_AFLPLUSPLUS ON CACHE BOOL "Use AFL++ instead of libFuzzer" FORCE)
+        message(STATUS "AFL++ compiler detected - automatically enabling AFL++ mode")
     endif()
-    if(LEXY_BUILD_BENCHMARKS)
-        add_subdirectory(benchmarks)
-    endif()
-    if(LEXY_BUILD_TESTS)
-        set(DOCTEST_NO_INSTALL ON)
-        enable_testing()
-        add_subdirectory(tests)
-    endif()
-    if(LEXY_BUILD_DOCS)
-        add_subdirectory(docs EXCLUDE_FROM_ALL)
+
+    add_subdirectory(src)
+    add_subdirectory(fuzzers)
+else()
+    add_subdirectory(src)
+
+    if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+        cmake_minimum_required(VERSION 3.18)
+        option(LEXY_BUILD_BENCHMARKS "whether or not benchmarks should be built" OFF)
+        option(LEXY_BUILD_EXAMPLES   "whether or not examples should be built" ON)
+        option(LEXY_BUILD_TESTS      "whether or not tests should be built" ON)
+        option(LEXY_BUILD_DOCS       "whether or not docs should be built" OFF)
+        option(LEXY_BUILD_PACKAGE    "whether or not the package should be built" ON)
+        option(LEXY_ENABLE_INSTALL   "whether or not to enable the install rule" ON)
+
+        # Optional components
+        if(LEXY_BUILD_EXAMPLES)
+            add_subdirectory(examples)
+        endif()
+        if(LEXY_BUILD_BENCHMARKS)
+            add_subdirectory(benchmarks)
+        endif()
+        if(LEXY_BUILD_TESTS)
+            set(DOCTEST_NO_INSTALL ON)
+            enable_testing()
+            add_subdirectory(tests)
+        endif()
+        if(LEXY_BUILD_DOCS)
+            add_subdirectory(docs EXCLUDE_FROM_ALL)
+        endif()
+
+        # Package creation
+        if(LEXY_BUILD_PACKAGE)
+            set(package_files include/ src/ cmake/ CMakeLists.txt LICENSE)
+            add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip
+                COMMAND ${CMAKE_COMMAND} -E tar c ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip --format=zip -- ${package_files}
+                WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+                DEPENDS ${package_files})
+            add_custom_target(lexy_package DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/lexy-src.zip)
+        endif()
+
+        # Installation configuration
+        if(LEXY_ENABLE_INSTALL)
+            include(CMakePackageConfigHelpers)
+            include(GNUInstallDirs)
+
+            install(TARGETS lexy lexy_core lexy_file lexy_unicode lexy_ext _lexy_base lexy_dev
+                EXPORT ${PROJECT_NAME}Targets
+                RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+                LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+                ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+            install(EXPORT ${PROJECT_NAME}Targets
+                NAMESPACE foonathan::
+                DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+            configure_package_config_file(
+                cmake/lexyConfig.cmake.in
+                "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+                INSTALL_DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+            install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
+                DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+            write_basic_package_version_file(
+                "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+                COMPATIBILITY SameMinorVersion)
+
+            install(FILES "${PROJECT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
+                DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}")
+
+            install(DIRECTORY include/lexy include/lexy_ext
+                DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+                FILES_MATCHING
+                PATTERN "*.hpp")
+        endif()
     endif()
 endif()

--- a/cmake/Fuzzing.cmake
+++ b/cmake/Fuzzing.cmake
@@ -1,0 +1,80 @@
+# Fuzzing configuration for lexy
+# Copyright (C) 2020-2025 Jonathan Müller and lexy contributors
+# SPDX-License-Identifier: BSL-1.0
+
+# Fuzzing options
+option(LEXY_BUILD_FUZZERS "whether or not fuzzers should be built" OFF)
+option(LEXY_BUILD_FUZZERS_AFLPLUSPLUS "Use AFL++ instead of libFuzzer" OFF)
+option(FORCE_STATIC_LINKING "Force static linking for fuzzing targets" OFF)
+
+# Check compiler requirements if fuzzing is enabled
+function(setup_fuzzing_environment)
+  if(NOT LEXY_BUILD_FUZZERS)
+    return()
+  endif()
+
+  # Verify we're using Clang
+  execute_process(
+        COMMAND ${CMAKE_CXX_COMPILER} --version
+        OUTPUT_VARIABLE CXX_COMPILER_VERSION
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+  if(NOT CXX_COMPILER_VERSION MATCHES "clang")
+    message(FATAL_ERROR "Fuzzing requires a Clang-based compiler")
+  endif()
+
+  # Auto-detect AFL compiler
+  if(CMAKE_C_COMPILER MATCHES ".*afl-.*" OR CMAKE_CXX_COMPILER MATCHES ".*afl-.*")
+    set(LEXY_BUILD_FUZZERS_AFLPLUSPLUS ON CACHE BOOL "Use AFL++ instead of libFuzzer" FORCE)
+    message(STATUS "AFL++ compiler detected - automatically enabling AFL++ mode")
+  endif()
+
+  # Add sanitizer flags for better fuzzing
+  if(NOT DEFINED ENV{SANITIZER})
+    set(ENV{SANITIZER} "address")
+  endif()
+
+  # Add fuzzers directory
+  add_subdirectory(fuzzers)
+endfunction()
+
+# Function to add a fuzzing target
+function(add_fuzzer name)
+  if(NOT LEXY_BUILD_FUZZERS)
+    return()
+  endif()
+
+  set(options "")
+  set(oneValueArgs "")
+  set(multiValueArgs SOURCES INCLUDES LIBRARIES)
+  cmake_parse_arguments(FUZZER "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+  add_executable(${name} ${FUZZER_SOURCES})
+
+  if(FUZZER_INCLUDES)
+    target_include_directories(${name} PRIVATE ${FUZZER_INCLUDES})
+  endif()
+
+  target_link_libraries(${name} PRIVATE ${FUZZER_LIBRARIES})
+
+  # Configure fuzzer specific flags
+  if(LEXY_BUILD_FUZZERS_AFLPLUSPLUS)
+    # AFL++ configuration
+    target_compile_options(${name} PRIVATE -fno-omit-frame-pointer -gline-tables-only)
+  else()
+    # libFuzzer configuration
+    target_compile_options(${name} PRIVATE -fsanitize=fuzzer -fno-omit-frame-pointer)
+    target_link_options(${name} PRIVATE -fsanitize=fuzzer)
+  endif()
+
+  # Add sanitizer if specified
+  if(DEFINED ENV{SANITIZER} AND NOT "$ENV{SANITIZER}" STREQUAL "none")
+    target_compile_options(${name} PRIVATE -fsanitize=$ENV{SANITIZER})
+    target_link_options(${name} PRIVATE -fsanitize=$ENV{SANITIZER})
+  endif()
+
+  # Handle static linking option
+  if(FORCE_STATIC_LINKING)
+    target_link_options(${name} PRIVATE -static)
+  endif()
+endfunction()

--- a/fuzzers/CMakeLists.txt
+++ b/fuzzers/CMakeLists.txt
@@ -1,40 +1,22 @@
-cmake_minimum_required(VERSION 3.18)
+# Copyright (C) 2020-2025 Jonathan Müller and lexy contributors
+# SPDX-License-Identifier: BSL-1.0
 
-set(BASE_FLAGS -O2 -ggdb -fno-omit-frame-pointer)
-
-if(FORCE_STATIC_LINKING)
-    set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
-    set(BUILD_SHARED_LIBS OFF)
+# Only process this file if fuzzing is enabled
+if(NOT LEXY_BUILD_FUZZERS)
+    return()
 endif()
 
-# Handle fuzzing-specific settings
-if(LEXY_FUZZING_ENGINE STREQUAL "libfuzzer")
-    # For libFuzzer, use fuzzer-no-link for the library
-    set(SANITIZER_FLAGS
-        -fsanitize=address,undefined,fuzzer-no-link
-    )
+# Create directories for corpus and artifacts
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/corpus)
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/artifacts)
 
-    set(FUZZING_FLAGS
-        -fsanitize=fuzzer,address,undefined
-    )
-else()  # AFL
-    set(SANITIZER_FLAGS
-        -fsanitize=address,undefined
-    )
-
-    set(FUZZING_FLAGS
-        -fsanitize=fuzzer
-    )
-endif()
-
-add_compile_options(${BASE_FLAGS} ${SANITIZER_FLAGS})
-add_link_options(${BASE_FLAGS} ${SANITIZER_FLAGS})
-
+# Wrapper around the add_fuzzer function that adds lexy-specific configuration
 function(add_lexy_fuzzer TARGET_NAME SOURCE_FILE EXAMPLE_FILE SEED_CONTENT)
-    # Create corpus directories
+    # Create corpus directories for this specific fuzzer
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_corpus)
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_artifacts)
 
+    # Copy example file if it exists
     if(EXISTS "${CMAKE_SOURCE_DIR}/examples/${EXAMPLE_FILE}")
         configure_file(
             ${CMAKE_SOURCE_DIR}/examples/${EXAMPLE_FILE}
@@ -43,76 +25,32 @@ function(add_lexy_fuzzer TARGET_NAME SOURCE_FILE EXAMPLE_FILE SEED_CONTENT)
         )
     endif()
 
+    # Create seed content
     file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_corpus/simple.${TARGET_NAME}
         "${SEED_CONTENT}"
     )
 
-    add_executable(${TARGET_NAME} ${SOURCE_FILE})
-
-    target_compile_options(${TARGET_NAME} PRIVATE
-        ${BASE_FLAGS}
-        ${SANITIZER_FLAGS}
-        ${FUZZING_FLAGS}
-    )
-
-    # Handle static linking options
-    if(FORCE_STATIC_LINKING)
-        if(LEXY_FUZZING_ENGINE STREQUAL "libfuzzer")
-            target_link_options(${TARGET_NAME} PRIVATE
-                ${BASE_FLAGS}
-                ${FUZZING_FLAGS}
-                ${SANITIZER_FLAGS}
-                -static-libstdc++
-                -static-libgcc
-            )
-        else() # AFL
-            target_link_options(${TARGET_NAME} PRIVATE
-                ${BASE_FLAGS}
-                ${SANITIZER_FLAGS}
-                ${FUZZING_FLAGS}
-                -static-libstdc++
-                -static-libgcc
-            )
-        endif()
-    else()
-        target_link_options(${TARGET_NAME} PRIVATE
-            ${BASE_FLAGS}
-            ${SANITIZER_FLAGS}
-            ${FUZZING_FLAGS}
-        )
-    endif()
-
-    # Link against the libraries
-    if(FORCE_STATIC_LINKING)
-        target_link_libraries(${TARGET_NAME}
-            PRIVATE
-            -static-libstdc++
-            -static-libgcc
+    # Add the fuzzer using our common function from Fuzzing.cmake
+    add_fuzzer(${TARGET_NAME}
+        SOURCES
+            ${SOURCE_FILE}
+        INCLUDES
+            ${CMAKE_CURRENT_SOURCE_DIR}/../include
+            ${CMAKE_CURRENT_BINARY_DIR}
+        LIBRARIES
             lexy_core
             lexy_file
             lexy_unicode
-        )
-    else()
-        target_link_libraries(${TARGET_NAME}
-            PRIVATE
-            lexy_core
-            lexy_file
-            lexy_unicode
-        )
-    endif()
-
-    target_include_directories(${TARGET_NAME}
-        PRIVATE
-        ${CMAKE_CURRENT_SOURCE_DIR}/../include
-        ${CMAKE_CURRENT_BINARY_DIR}
     )
 
+    # Set output directory
     set_target_properties(${TARGET_NAME}
         PROPERTIES
         RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
     )
 endfunction()
 
+# Add the fuzzers
 add_lexy_fuzzer(
     json_fuzzer
     json_fuzzer.cpp

--- a/fuzzers/CMakeLists.txt
+++ b/fuzzers/CMakeLists.txt
@@ -1,0 +1,149 @@
+cmake_minimum_required(VERSION 3.18)
+
+set(BASE_FLAGS -O2 -ggdb -fno-omit-frame-pointer)
+
+if(FORCE_STATIC_LINKING)
+    set(CMAKE_FIND_LIBRARY_SUFFIXES .a ${CMAKE_FIND_LIBRARY_SUFFIXES})
+    set(BUILD_SHARED_LIBS OFF)
+endif()
+
+# Handle fuzzing-specific settings
+if(LEXY_FUZZING_ENGINE STREQUAL "libfuzzer")
+    # For libFuzzer, use fuzzer-no-link for the library
+    set(SANITIZER_FLAGS
+        -fsanitize=address,undefined,fuzzer-no-link
+    )
+
+    set(FUZZING_FLAGS
+        -fsanitize=fuzzer,address,undefined
+    )
+else()  # AFL
+    set(SANITIZER_FLAGS
+        -fsanitize=address,undefined
+    )
+
+    set(FUZZING_FLAGS
+        -fsanitize=fuzzer
+    )
+endif()
+
+add_compile_options(${BASE_FLAGS} ${SANITIZER_FLAGS})
+add_link_options(${BASE_FLAGS} ${SANITIZER_FLAGS})
+
+function(add_lexy_fuzzer TARGET_NAME SOURCE_FILE EXAMPLE_FILE SEED_CONTENT)
+    # Create corpus directories
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_corpus)
+    file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_artifacts)
+
+    if(EXISTS "${CMAKE_SOURCE_DIR}/examples/${EXAMPLE_FILE}")
+        configure_file(
+            ${CMAKE_SOURCE_DIR}/examples/${EXAMPLE_FILE}
+            ${CMAKE_CURRENT_BINARY_DIR}/${EXAMPLE_FILE}
+            COPYONLY
+        )
+    endif()
+
+    file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}_corpus/simple.${TARGET_NAME}
+        "${SEED_CONTENT}"
+    )
+
+    add_executable(${TARGET_NAME} ${SOURCE_FILE})
+
+    target_compile_options(${TARGET_NAME} PRIVATE
+        ${BASE_FLAGS}
+        ${SANITIZER_FLAGS}
+        ${FUZZING_FLAGS}
+    )
+
+    # Handle static linking options
+    if(FORCE_STATIC_LINKING)
+        if(LEXY_FUZZING_ENGINE STREQUAL "libfuzzer")
+            target_link_options(${TARGET_NAME} PRIVATE
+                ${BASE_FLAGS}
+                ${FUZZING_FLAGS}
+                ${SANITIZER_FLAGS}
+                -static-libstdc++
+                -static-libgcc
+            )
+        else() # AFL
+            target_link_options(${TARGET_NAME} PRIVATE
+                ${BASE_FLAGS}
+                ${SANITIZER_FLAGS}
+                ${FUZZING_FLAGS}
+                -static-libstdc++
+                -static-libgcc
+            )
+        endif()
+    else()
+        target_link_options(${TARGET_NAME} PRIVATE
+            ${BASE_FLAGS}
+            ${SANITIZER_FLAGS}
+            ${FUZZING_FLAGS}
+        )
+    endif()
+
+    # Link against the libraries
+    if(FORCE_STATIC_LINKING)
+        target_link_libraries(${TARGET_NAME}
+            PRIVATE
+            -static-libstdc++
+            -static-libgcc
+            lexy_core
+            lexy_file
+            lexy_unicode
+        )
+    else()
+        target_link_libraries(${TARGET_NAME}
+            PRIVATE
+            lexy_core
+            lexy_file
+            lexy_unicode
+        )
+    endif()
+
+    target_include_directories(${TARGET_NAME}
+        PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/../include
+        ${CMAKE_CURRENT_BINARY_DIR}
+    )
+
+    set_target_properties(${TARGET_NAME}
+        PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}"
+    )
+endfunction()
+
+add_lexy_fuzzer(
+    json_fuzzer
+    json_fuzzer.cpp
+    json.cpp
+    "{\"test\": true, \"number\": 42, \"string\": \"hello\", \"array\": [1,2,3]}"
+)
+
+add_lexy_fuzzer(
+    xml_fuzzer
+    xml_fuzzer.cpp
+    xml.cpp
+    "<root><test>Hello</test><data><![CDATA[Test data]]></data><empty/></root>"
+)
+
+add_lexy_fuzzer(
+    parse_tree_fuzzer
+    parse_tree_fuzzer.cpp
+    "parse_tree.hpp"
+    "<root><node>Sample</node></root>"
+)
+
+add_lexy_fuzzer(
+    visualize_fuzzer
+    visualize_fuzzer.cpp
+    "visualize.hpp"
+    "normal string\n\\u0041\\u0042\\n\\t\\r\\u{10FFFF}\\u{000000}\n<unicode>⚡️🌈🌍</unicode>\n\\u0000"
+)
+
+add_lexy_fuzzer(
+    buffer_fuzzer
+    buffer_fuzzer.cpp
+    "_detail/buffer_builder.hpp"
+    "ABCD\\0\\xFF\\x80\\xFE\\0\\1\\2\\3\\4\\5\\6\\7\\x42\\xAA\\xBB\\xCC\\xDD"
+)

--- a/fuzzers/README.md
+++ b/fuzzers/README.md
@@ -1,0 +1,86 @@
+# Lexy Fuzzers
+
+This directory contains fuzzers for testing the lexy library. The fuzzing infrastructure supports both libFuzzer and AFL++ as fuzzing engines, with various sanitizer options.
+
+## Available Fuzzers
+
+- **json_fuzzer**: Tests JSON parsing
+- **xml_fuzzer**: Tests XML parsing
+- **parse_tree_fuzzer**: Tests parse tree generation
+- **visualize_fuzzer**: Tests visualization components
+- **buffer_fuzzer**: Tests the internal buffer implementation
+
+## Building the Fuzzers
+
+### Basic Build with libFuzzer (default)
+
+```bash
+# Create and enter a build directory
+mkdir -p build_fuzzer && cd build_fuzzer
+
+# Configure with fuzzing enabled
+cmake -DLEXY_BUILD_FUZZERS=ON ..
+
+# Build all fuzzers
+cmake --build . --parallel
+```
+
+### Building with AFL++
+
+Requires AFL++ to be installed on the system
+
+```bash
+# Create and enter a build directory
+mkdir -p build_afl && cd build_afl
+
+# Configure with AFL++ (make sure you're using the afl-clang-fast compiler)
+export CC=afl-clang-fast
+export CXX=afl-clang-fast++
+cmake -DLEXY_BUILD_FUZZERS=ON ..
+
+# Build all fuzzers
+cmake --build . --parallel
+```
+
+### Building with different sanitizers
+
+```bash
+# Create and enter a build directory
+mkdir -p build_fuzzer_asan && cd build_fuzzer_asan
+
+# Configure with Address Sanitizer (default if not specified)
+export SANITIZER=address
+cmake -DLEXY_BUILD_FUZZERS=ON ..
+
+# Build all fuzzers
+cmake --build . --parallel
+```
+
+### Build with static linking
+
+```bash
+# Create and enter a build directory
+mkdir -p build_fuzzer_static && cd build_fuzzer_static
+
+# Configure with static linking
+cmake -DLEXY_BUILD_FUZZERS=ON -DFORCE_STATIC_LINKING=ON ..
+
+# Build all fuzzers
+cmake --build . --parallel
+```
+
+### Combining options
+
+```bash
+# Create and enter a build directory
+mkdir -p build_afl_msan_static && cd build_afl_msan_static
+
+# Configure with AFL++, memory sanitizer, and static linking
+export CC=afl-clang-fast
+export CXX=afl-clang-fast++
+export SANITIZER=memory
+cmake -DLEXY_BUILD_FUZZERS=ON -DFORCE_STATIC_LINKING=ON ..
+
+# Build all fuzzers
+cmake --build . --parallel
+```

--- a/fuzzers/buffer_fuzzer.cpp
+++ b/fuzzers/buffer_fuzzer.cpp
@@ -1,0 +1,120 @@
+#include <cstddef>
+#include <cstdint>
+#include <fuzzer/FuzzedDataProvider.h>
+#include <string>
+
+#define LEXY_TEST
+#include <lexy/_detail/buffer_builder.hpp>
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+    if (Size < 4)
+        return 0;
+
+    FuzzedDataProvider fuzz_data(Data, Size);
+
+    // Choose buffer type
+    auto type = fuzz_data.ConsumeIntegralInRange<int>(0, 2);
+
+    try
+    {
+        switch (type)
+        {
+        case 0: {
+            // char buffer - test basic operations
+            lexy::_detail::buffer_builder<char> buffer;
+
+            while (fuzz_data.remaining_bytes() > 0)
+            {
+                switch (fuzz_data.ConsumeIntegralInRange<int>(0, 3))
+                {
+                case 0: { // Write and commit
+                    const auto write_size = buffer.write_size();
+                    if (write_size > 0 && fuzz_data.remaining_bytes() > 0)
+                    {
+                        // Ensure max is at least 1
+                        const auto max_size
+                            = std::max(std::min(write_size, fuzz_data.remaining_bytes()),
+                                       size_t(1));
+                        const auto n = fuzz_data.ConsumeIntegralInRange<size_t>(1, max_size);
+
+                        auto bytes = fuzz_data.ConsumeBytes<uint8_t>(n);
+                        if (bytes.size() == n)
+                        {
+                            std::memcpy(buffer.write_data(), bytes.data(), n);
+                            buffer.commit(n);
+                        }
+                    }
+                    break;
+                }
+                case 1: // Clear
+                    buffer.clear();
+                    break;
+                case 2: // Grow
+                    buffer.grow();
+                    break;
+                case 3: { // Read using iterator
+                    if (buffer.read_size() > 0)
+                    {
+                        using iterator = typename decltype(buffer)::stable_iterator;
+                        iterator it(buffer, 0);
+                        iterator end(buffer, buffer.read_size());
+                        while (it != end)
+                        {
+                            volatile auto ch = *it;
+                            (void)ch;
+                            ++it;
+                        }
+                    }
+                    break;
+                }
+                }
+            }
+            break;
+        }
+        case 1: {
+            // int buffer - test element alignment
+            lexy::_detail::buffer_builder<int> buffer;
+            while (fuzz_data.remaining_bytes() >= sizeof(int))
+            {
+                if (buffer.write_size() > 0)
+                {
+                    int value = fuzz_data.ConsumeIntegral<int>();
+                    std::memcpy(buffer.write_data(), &value, sizeof(int));
+                    buffer.commit(1);
+                }
+                else
+                {
+                    buffer.grow();
+                }
+            }
+            break;
+        }
+        case 2: {
+            // double buffer - test larger alignment
+            lexy::_detail::buffer_builder<double> buffer;
+            while (fuzz_data.remaining_bytes() >= sizeof(double))
+            {
+                if (buffer.write_size() > 0)
+                {
+                    std::vector<uint8_t> bytes = fuzz_data.ConsumeBytes<uint8_t>(sizeof(double));
+                    if (bytes.size() == sizeof(double))
+                    {
+                        std::memcpy(buffer.write_data(), bytes.data(), sizeof(double));
+                        buffer.commit(1);
+                    }
+                }
+                else
+                {
+                    buffer.grow();
+                }
+            }
+            break;
+        }
+        }
+    }
+    catch (...)
+    {}
+
+    return 0;
+}

--- a/fuzzers/json_fuzzer.cpp
+++ b/fuzzers/json_fuzzer.cpp
@@ -1,0 +1,251 @@
+#include <cstddef>
+#include <cstdint>
+#include <fuzzer/FuzzedDataProvider.h>
+#include <limits>
+#include <string>
+#include <vector>
+
+// Define this to prevent the original main from being included
+#define LEXY_TEST
+
+// Include the original json implementation
+#include "json.cpp"
+
+#undef LEXY_TEST
+
+// Helper function to generate JSON number strings
+std::string generateNumber(FuzzedDataProvider& fuzz_data)
+{
+    std::string num;
+    if (fuzz_data.ConsumeBool())
+    {
+        num += "-";
+    }
+
+    // Generate integer part
+    if (fuzz_data.ConsumeBool())
+    {
+        num += std::to_string(fuzz_data.ConsumeIntegral<int64_t>());
+    }
+    else
+    {
+        num += std::to_string(fuzz_data.ConsumeIntegralInRange<int>(0, 9));
+    }
+
+    // Maybe add fraction
+    if (fuzz_data.ConsumeBool())
+    {
+        num += ".";
+        num += std::to_string(fuzz_data.ConsumeIntegralInRange<unsigned>(0, 999999));
+    }
+
+    // Maybe add exponent
+    if (fuzz_data.ConsumeBool())
+    {
+        num += fuzz_data.ConsumeBool() ? "e" : "E";
+        num += fuzz_data.ConsumeBool() ? "+" : "-";
+        num += std::to_string(fuzz_data.ConsumeIntegralInRange<int16_t>(0, 999));
+    }
+
+    return num;
+}
+
+// Helper function to generate JSON strings with escapes
+std::string generateString(FuzzedDataProvider& fuzz_data)
+{
+    std::string str    = "\"";
+    size_t      length = fuzz_data.ConsumeIntegralInRange<size_t>(0, 32);
+
+    for (size_t i = 0; i < length; ++i)
+    {
+        if (fuzz_data.ConsumeBool())
+        {
+            // Generate escape sequence
+            switch (fuzz_data.ConsumeIntegralInRange<int>(0, 7))
+            {
+            case 0:
+                str += "\\\"";
+                break;
+            case 1:
+                str += "\\\\";
+                break;
+            case 2:
+                str += "\\n";
+                break;
+            case 3:
+                str += "\\r";
+                break;
+            case 4:
+                str += "\\t";
+                break;
+            case 5:
+                str += "\\b";
+                break;
+            case 6:
+                str += "\\f";
+                break;
+            case 7:
+                // Unicode escape
+                char unicode[7];
+                std::snprintf(unicode, sizeof(unicode), "\\u%04x",
+                              fuzz_data.ConsumeIntegralInRange<unsigned>(0, 0xFFFF));
+                str += unicode;
+                break;
+            }
+        }
+        else
+        {
+            // Regular printable character
+            char c = fuzz_data.ConsumeIntegralInRange<char>(32, 126);
+            str += c;
+        }
+    }
+
+    str += "\"";
+    return str;
+}
+
+// Helper function to generate nested JSON structures
+std::string generateJSON(FuzzedDataProvider& fuzz_data, int depth = 0)
+{
+    if (depth > 5 || fuzz_data.remaining_bytes() < 2)
+    {
+        // Generate primitive values at max depth or low remaining bytes
+        switch (fuzz_data.ConsumeIntegralInRange<int>(0, 4))
+        {
+        case 0:
+            return "null";
+        case 1:
+            return fuzz_data.ConsumeBool() ? "true" : "false";
+        case 2:
+            return generateNumber(fuzz_data);
+        case 3:
+            return generateString(fuzz_data);
+        default:
+            return "null";
+        }
+    }
+
+    // Generate complex structures
+    switch (fuzz_data.ConsumeIntegralInRange<int>(0, 6))
+    {
+    case 0: // Array
+    {
+        std::string arr      = "[";
+        int         elements = fuzz_data.ConsumeIntegralInRange<int>(0, 5);
+        for (int i = 0; i < elements; ++i)
+        {
+            if (i > 0)
+                arr += ",";
+            arr += generateJSON(fuzz_data, depth + 1);
+        }
+        arr += "]";
+        return arr;
+    }
+
+    case 1: // Object
+    {
+        std::string obj   = "{";
+        int         pairs = fuzz_data.ConsumeIntegralInRange<int>(0, 5);
+        for (int i = 0; i < pairs; ++i)
+        {
+            if (i > 0)
+                obj += ",";
+            obj += generateString(fuzz_data) + ":" + generateJSON(fuzz_data, depth + 1);
+        }
+        obj += "}";
+        return obj;
+    }
+
+    default: // Primitives with higher probability
+        switch (fuzz_data.ConsumeIntegralInRange<int>(0, 3))
+        {
+        case 0:
+            return "null";
+        case 1:
+            return fuzz_data.ConsumeBool() ? "true" : "false";
+        case 2:
+            return generateNumber(fuzz_data);
+        case 3:
+            return generateString(fuzz_data);
+        }
+    }
+
+    return "null";
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+    if (Size < 4)
+        return 0; // Require minimum input size
+
+    FuzzedDataProvider fuzz_data(Data, Size);
+
+    // Generate structured JSON with probability
+    std::string input;
+    if (fuzz_data.ConsumeBool())
+    {
+        // Generate well-formed JSON
+        input = generateJSON(fuzz_data);
+    }
+    else
+    {
+        // Generate potentially malformed JSON for edge cases
+        static const char structural[] = "{}[],:\"";
+        while (fuzz_data.remaining_bytes() > 0)
+        {
+            switch (fuzz_data.ConsumeIntegralInRange<int>(0, 4))
+            {
+            case 0: { // Structural characters
+                input += structural[fuzz_data.ConsumeIntegralInRange<size_t>(0, 5)];
+                break;
+            }
+
+            case 1: { // Numbers
+                input += generateNumber(fuzz_data);
+                break;
+            }
+
+            case 2: { // Strings
+                input += generateString(fuzz_data);
+                break;
+            }
+
+            case 3: { // Keywords
+                switch (fuzz_data.ConsumeIntegralInRange<int>(0, 2))
+                {
+                case 0:
+                    input += "null";
+                    break;
+                case 1:
+                    input += "true";
+                    break;
+                case 2:
+                    input += "false";
+                    break;
+                }
+                break;
+            }
+
+            case 4: { // Random data
+                input += fuzz_data.ConsumeRandomLengthString(16);
+                break;
+            }
+            }
+        }
+    }
+
+    // Create a buffer from the generated input
+    auto buffer = lexy::buffer<lexy::utf8_encoding>(input.data(), input.size());
+
+    // Try to parse the JSON
+    auto result = lexy::parse<grammar::json>(buffer, lexy_ext::report_error);
+
+    if (result.has_value())
+    {
+        // For valid JSON, also test the printing functionality
+        result.value().print();
+    }
+
+    return 0;
+}

--- a/fuzzers/json_grammar.hpp
+++ b/fuzzers/json_grammar.hpp
@@ -1,0 +1,250 @@
+#pragma once
+
+#include <cinttypes>
+#include <cstdint>
+#include <cstdio>
+#include <map>
+#include <optional>
+#include <string>
+#include <variant>
+#include <vector>
+
+#include <lexy/action/parse.hpp>
+#include <lexy/callback.hpp>
+#include <lexy/dsl.hpp>
+#include <lexy/input/file.hpp>
+#include <lexy_ext/report_error.hpp>
+
+// The complete AST definition
+namespace ast
+{
+struct json_value;
+
+using json_null = std::nullptr_t;
+using json_bool = bool;
+
+struct json_number
+{
+    std::int64_t                integer;
+    std::optional<std::string>  fraction;
+    std::optional<std::int16_t> exponent;
+};
+
+using json_string = std::string;
+using json_array  = std::vector<json_value>;
+using json_object = std::map<std::string, json_value>;
+
+struct json_value
+{
+    std::variant<json_null, json_bool, json_number, json_string, json_array, json_object> v;
+
+    template <typename T>
+    json_value(T t) : v(std::move(t))
+    {}
+
+    void _indent(int level) const
+    {
+        for (auto i = 0; i < level; ++i)
+            std::fputc(' ', stdout);
+    }
+
+    void _print(json_null, int) const
+    {
+        std::fputs("null", stdout);
+    }
+
+    void _print(json_bool b, int) const
+    {
+        std::fputs(b ? "true" : "false", stdout);
+    }
+
+    void _print(const json_number& n, int) const
+    {
+        std::printf("%" PRId64, n.integer);
+        if (n.fraction)
+        {
+            std::printf(".%s", n.fraction->c_str());
+        }
+        if (n.exponent)
+        {
+            std::printf("e%" PRId16, *n.exponent);
+        }
+    }
+
+    void _print(const json_string& str, int) const
+    {
+        std::fputc('"', stdout);
+        for (auto c : str)
+        {
+            if (c == '"')
+                std::fputs("\\\"", stdout);
+            else if (c == '\\')
+                std::fputs("\\\\", stdout);
+            else if (std::iscntrl(c))
+                std::printf("\\u%04x", static_cast<unsigned char>(c));
+            else
+                std::fputc(c, stdout);
+        }
+        std::fputc('"', stdout);
+    }
+
+    void _print(const json_array& arr, int level) const
+    {
+        std::fputs("[\n", stdout);
+        bool first = true;
+        for (const auto& elem : arr)
+        {
+            if (!first)
+                std::fputs(",\n", stdout);
+            first = false;
+            _indent(level + 2);
+            elem.print(level + 2);
+        }
+        std::fputs("\n", stdout);
+        _indent(level);
+        std::fputc(']', stdout);
+    }
+
+    void _print(const json_object& obj, int level) const
+    {
+        std::fputs("{\n", stdout);
+        bool first = true;
+        for (const auto& [key, value] : obj)
+        {
+            if (!first)
+                std::fputs(",\n", stdout);
+            first = false;
+            _indent(level + 2);
+            _print(key, level + 2);
+            std::fputs(": ", stdout);
+            value.print(level + 2);
+        }
+        std::fputs("\n", stdout);
+        _indent(level);
+        std::fputc('}', stdout);
+    }
+
+    void print(int level = 0) const
+    {
+        std::visit([this, level](const auto& value) { this->_print(value, level); }, v);
+    }
+};
+} // namespace ast
+
+// The complete grammar definition
+namespace grammar
+{
+namespace dsl = lexy::dsl;
+
+struct json_value; // Forward declaration needed
+
+struct null : lexy::token_production
+{
+    static constexpr auto rule  = LEXY_LIT("null");
+    static constexpr auto value = lexy::construct<ast::json_null>;
+};
+
+struct boolean : lexy::token_production
+{
+    struct true_ : lexy::transparent_production
+    {
+        static constexpr auto rule  = LEXY_LIT("true");
+        static constexpr auto value = lexy::constant(true);
+    };
+    struct false_ : lexy::transparent_production
+    {
+        static constexpr auto rule  = LEXY_LIT("false");
+        static constexpr auto value = lexy::constant(false);
+    };
+
+    static constexpr auto rule  = dsl::p<true_> | dsl::p<false_>;
+    static constexpr auto value = lexy::forward<ast::json_bool>;
+};
+
+struct number : lexy::token_production
+{
+    // A signed integer parsed as int64_t
+    struct integer : lexy::transparent_production
+    {
+        static constexpr auto rule  = dsl::minus_sign.opt() >> dsl::integer<std::int64_t>;
+        static constexpr auto value = lexy::as_integer<std::int64_t>;
+    };
+
+    // The fractional part of a number
+    struct fraction : lexy::transparent_production
+    {
+        static constexpr auto rule  = dsl::lit_c<'.'> >> dsl::capture(dsl::digits<>);
+        static constexpr auto value = lexy::as_string<std::string>;
+    };
+
+    // The exponent of a number
+    struct exponent : lexy::transparent_production
+    {
+        static constexpr auto rule
+            = (dsl::lit_c<'e'> | dsl::lit_c<'E'>) >> dsl::sign + dsl::integer<std::int16_t>;
+        static constexpr auto value = lexy::as_integer<std::int16_t>;
+    };
+
+    static constexpr auto rule
+        = dsl::p<integer> + dsl::opt(dsl::p<fraction>) + dsl::opt(dsl::p<exponent>);
+    static constexpr auto value = lexy::construct<ast::json_number>;
+};
+
+struct string : lexy::token_production
+{
+    struct invalid_char
+    {
+        static LEXY_CONSTEVAL auto name()
+        {
+            return "invalid character in string literal";
+        }
+    };
+
+    // Escape sequence mapping
+    static constexpr auto escaped_symbols = lexy::symbol_table<char>
+            .map<'"'>('"')
+            .map<'\\'>('\\')
+            .map<'/'>('/')
+            .map<'b'>('\b')
+            .map<'f'>('\f')
+            .map<'n'>('\n')
+            .map<'r'>('\r')
+            .map<'t'>('\t');
+
+    static constexpr auto rule = [] {
+        auto char_set = (-dsl::unicode::control).error<invalid_char>;
+        auto escape   = dsl::backslash_escape.symbol<escaped_symbols>();
+        return dsl::quoted(char_set, escape);
+    }();
+    static constexpr auto value = lexy::as_string<ast::json_string>;
+};
+
+struct array
+{
+    static constexpr auto rule
+        = dsl::square_bracketed.opt_list(dsl::recurse<json_value>, dsl::sep(dsl::comma));
+    static constexpr auto value = lexy::as_list<ast::json_array>;
+};
+
+struct object
+{
+    static constexpr auto rule
+        = dsl::curly_bracketed.opt_list(dsl::p<string> + dsl::colon + dsl::recurse<json_value>,
+                                        dsl::sep(dsl::comma));
+    static constexpr auto value = lexy::as_collection<ast::json_object>;
+};
+
+struct json_value : lexy::transparent_production
+{
+    static constexpr auto rule = dsl::p<null> | dsl::p<boolean> | dsl::p<number> | dsl::p<string>
+                                 | dsl::p<array> | dsl::p<object>;
+    static constexpr auto value = lexy::construct<ast::json_value>;
+};
+
+struct json
+{
+    static constexpr auto whitespace = dsl::ascii::space | dsl::ascii::newline;
+    static constexpr auto rule       = dsl::p<json_value> + dsl::eof;
+    static constexpr auto value      = lexy::forward<ast::json_value>;
+};
+} // namespace grammar

--- a/fuzzers/parse_tree_fuzzer.cpp
+++ b/fuzzers/parse_tree_fuzzer.cpp
@@ -1,0 +1,137 @@
+#include <cstddef>
+#include <cstdint>
+#include <fuzzer/FuzzedDataProvider.h>
+#include <string>
+#include <vector>
+
+#define LEXY_TEST
+#include <lexy/action/parse.hpp>
+#include <lexy/action/parse_as_tree.hpp>
+#include <lexy/dsl.hpp>
+#include <lexy/input/buffer.hpp>
+#include <lexy/input/string_input.hpp>
+#include <lexy/parse_tree.hpp>
+
+enum class token_kind
+{
+    a,
+    b,
+    c,
+};
+
+struct child_p
+{
+    static constexpr auto name = "child_p";
+    static constexpr auto rule = lexy::dsl::any;
+};
+
+struct root_p
+{
+    static constexpr auto name = "root_p";
+    static constexpr auto rule = lexy::dsl::any;
+};
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+    if (Size < 4)
+        return 0;
+
+    FuzzedDataProvider fuzz_data(Data, Size);
+    std::string        input = fuzz_data.ConsumeRandomLengthString(Size);
+
+    auto buffer = lexy::buffer<lexy::utf8_encoding>(input.data(), input.size());
+
+    using Tree = lexy::parse_tree_for<lexy::string_input<>, token_kind>;
+    Tree tree;
+
+    {
+        Tree::builder builder(root_p{});
+
+        // Always add at least one token to root to ensure valid positioning
+        if (input.size() > 0)
+        {
+            builder.token(token_kind::a, input.data(), input.data() + 1);
+        }
+
+        // Add additional tokens
+        size_t num_tokens = fuzz_data.ConsumeIntegralInRange<size_t>(0, 5);
+        for (size_t i = 0; i < num_tokens && input.size() > 1; ++i)
+        {
+            size_t pos = fuzz_data.ConsumeIntegralInRange<size_t>(0, input.size() - 2);
+            size_t len = fuzz_data.ConsumeIntegralInRange<size_t>(1, input.size() - pos - 1);
+
+            token_kind kind = static_cast<token_kind>(fuzz_data.ConsumeIntegralInRange<int>(0, 2));
+
+            builder.token(kind, input.data() + pos, input.data() + pos + len);
+        }
+
+        // Add productions with guaranteed token content
+        if (fuzz_data.ConsumeBool() && input.size() > 2)
+        {
+            auto marker = builder.start_production(child_p{});
+
+            // Ensure at least one token in production
+            size_t pos = fuzz_data.ConsumeIntegralInRange<size_t>(0, input.size() - 2);
+            builder.token(token_kind::a, input.data() + pos, input.data() + pos + 1);
+
+            // Add optional additional tokens
+            size_t num_child_tokens = fuzz_data.ConsumeIntegralInRange<size_t>(0, 3);
+            for (size_t i = 0; i < num_child_tokens && input.size() > pos + 2; ++i)
+            {
+                size_t token_pos
+                    = fuzz_data.ConsumeIntegralInRange<size_t>(pos + 1, input.size() - 2);
+                size_t len
+                    = fuzz_data.ConsumeIntegralInRange<size_t>(1, input.size() - token_pos - 1);
+                builder.token(token_kind::b, input.data() + token_pos,
+                              input.data() + token_pos + len);
+            }
+
+            builder.finish_production(std::move(marker));
+        }
+
+        // Create valid remaining input
+        tree = std::move(builder).finish(input.data() + input.size());
+    }
+
+    if (!tree.empty())
+    {
+        auto root = tree.root();
+
+        // Safe traversal checking node type before operations
+        for (auto [event, node] : tree.traverse(root))
+        {
+            // Check node kind first
+            auto kind = node.kind();
+
+            if (kind.is_token())
+            {
+                // Safe operations for token nodes
+                node.token();
+                node.lexeme();
+                node.position();
+            }
+
+            if (kind.is_production())
+            {
+                // Only do production operations if we have children
+                auto children = node.children();
+                if (!children.empty())
+                {
+                    // Position is only valid if the production has token descendants
+                    node.position();
+                    node.covering_lexeme();
+                }
+                node.parent();
+            }
+
+            // Safe operations for all nodes
+            if (!kind.is_root())
+            {
+                auto siblings = node.siblings();
+                node.is_last_child();
+            }
+        }
+    }
+
+    return 0;
+}

--- a/fuzzers/visualize_fuzzer.cpp
+++ b/fuzzers/visualize_fuzzer.cpp
@@ -1,0 +1,147 @@
+#include <cstddef>
+#include <cstdint>
+#include <fuzzer/FuzzedDataProvider.h>
+#include <iterator>
+#include <string>
+
+#define LEXY_TEST
+#include <lexy/dsl/any.hpp>
+#include <lexy/input/string_input.hpp>
+#include <lexy/visualize.hpp>
+
+// Keep token kinds for visualization testing
+enum class token_kind
+{
+    a,
+    b,
+    c,
+};
+
+const char* token_kind_name(token_kind k)
+{
+    switch (k)
+    {
+    case token_kind::a:
+        return "a";
+    case token_kind::b:
+        return "b";
+    case token_kind::c:
+        return "c";
+    default:
+        return "";
+    }
+}
+
+// Helper to generate potentially problematic strings for write_str
+std::string generate_deep_string(FuzzedDataProvider& fuzz_data)
+{
+    std::string result;
+
+    // Create deeply nested string with special characters
+    size_t depth = fuzz_data.ConsumeIntegralInRange<size_t>(1, 1000);
+    for (size_t i = 0; i < depth; i++)
+    {
+        // Add potentially problematic patterns that will cause write_str recursion
+        switch (fuzz_data.ConsumeIntegralInRange<int>(0, 3))
+        {
+        case 0: // Unicode escapes
+            result += "\\u";
+            result += fuzz_data.ConsumeRandomLengthString(4);
+            break;
+        case 1: // Nested escapes
+            result += "\\\\\\";
+            break;
+        case 2: // Control characters
+            result += std::string(1, fuzz_data.ConsumeIntegralInRange<char>(0, 31));
+            break;
+        case 3: // Special characters
+            result += "\t\n\r\"'<>&";
+            break;
+        }
+    }
+    return result;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+    if (Size < 4)
+        return 0;
+
+    FuzzedDataProvider fuzz_data(Data, Size);
+
+    // Create output string and iterator
+    std::string output;
+    auto        out = std::back_inserter(output);
+
+    // Create visualization options with fuzz data
+    lexy::visualization_options opts;
+    opts.flags
+        = static_cast<lexy::visualization_flags>(fuzz_data.ConsumeIntegralInRange<unsigned>(0, 15));
+    opts.max_tree_depth   = fuzz_data.ConsumeIntegralInRange<unsigned char>(0, 32);
+    opts.max_lexeme_width = fuzz_data.ConsumeIntegralInRange<unsigned char>(0, 255);
+    opts.tab_width        = fuzz_data.ConsumeIntegralInRange<unsigned char>(0, 8);
+
+    try
+    {
+        // Test 1: Code point visualization
+        {
+            // Generate some interesting code points
+            std::vector<lexy::code_point> code_points;
+
+            // Test control characters
+            code_points.push_back(lexy::code_point('\0'));
+            code_points.push_back(lexy::code_point('\n'));
+            code_points.push_back(lexy::code_point('\r'));
+            code_points.push_back(lexy::code_point('\t'));
+            code_points.push_back(lexy::code_point('\\'));
+
+            // Add fuzzed code points
+            while (fuzz_data.remaining_bytes() > 4)
+            {
+                auto cp_value = fuzz_data.ConsumeIntegral<char32_t>();
+                code_points.push_back(lexy::code_point(cp_value));
+            }
+
+            // Test all visualization flag combinations
+            for (const auto& cp : code_points)
+            {
+                lexy::visualize_to(out, cp, opts);
+                lexy::visualize_to(out, cp, opts | lexy::visualize_use_unicode);
+                lexy::visualize_to(out, cp, opts | lexy::visualize_use_color);
+                lexy::visualize_to(out, cp, opts | lexy::visualize_use_symbols);
+                lexy::visualize_to(out, cp, opts | lexy::visualize_space);
+            }
+        }
+
+        // Test 2: Deep string visualization targeting write_str
+        {
+            auto deep_string = generate_deep_string(fuzz_data);
+            auto input       = lexy::zstring_input(deep_string.c_str());
+            auto lexeme      = lexy::lexeme_for<decltype(input)>(input.data(),
+                                                                 input.data() + deep_string.size());
+
+            // Test with different encodings
+            lexy::visualize_to(out, lexeme, opts);
+            lexy::visualization_display_width(lexeme, opts);
+        }
+
+        // Test 3: Regular lexeme visualization
+        {
+            std::string test_input
+                = fuzz_data.ConsumeRandomLengthString(std::min(Size, size_t(64)));
+
+            auto input = lexy::zstring_input(test_input.c_str());
+            auto lexeme
+                = lexy::lexeme_for<decltype(input)>(input.data(), input.data() + test_input.size());
+
+            lexy::visualize_to(out, lexeme, opts);
+            lexy::visualize_to(out, lexeme, {opts.flags | lexy::visualize_use_unicode});
+            lexy::visualize_to(out, lexeme, {opts.flags | lexy::visualize_use_symbols});
+            lexy::visualization_display_width(lexeme, opts);
+        }
+    }
+    catch (...)
+    {}
+
+    return 0;
+}

--- a/fuzzers/xml_fuzzer.cpp
+++ b/fuzzers/xml_fuzzer.cpp
@@ -1,0 +1,293 @@
+#include <cstddef>
+#include <cstdint>
+#include <fuzzer/FuzzedDataProvider.h>
+#include <string>
+#include <vector>
+
+// Define this to prevent the original main from being included
+#define LEXY_TEST
+
+// Include the original XML implementation
+#include "xml.cpp"
+
+#undef LEXY_TEST
+
+// Helper function to generate XML tag names
+std::string generateTagName(FuzzedDataProvider& fuzz_data)
+{
+    static const char first_chars[] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_:";
+    static const char other_chars[]
+        = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_:-.";
+
+    std::string name;
+    // First character has more restrictions
+    name += first_chars[fuzz_data.ConsumeIntegralInRange<size_t>(0, sizeof(first_chars) - 2)];
+
+    // Rest of the name
+    size_t len = fuzz_data.ConsumeIntegralInRange<size_t>(0, 10);
+    for (size_t i = 0; i < len; ++i)
+    {
+        name += other_chars[fuzz_data.ConsumeIntegralInRange<size_t>(0, sizeof(other_chars) - 2)];
+    }
+    return name;
+}
+
+// Helper function to generate entity references
+std::string generateEntityRef(FuzzedDataProvider& fuzz_data)
+{
+    static const char* entities[] = {"&quot;", "&amp;", "&apos;", "&lt;", "&gt;",
+                                     // Add some invalid ones for testing
+                                     "&invalid;", "&test", "&;", "&&;", "&quot"};
+    return entities[fuzz_data.ConsumeIntegralInRange<size_t>(0,
+                                                             sizeof(entities) / sizeof(entities[0])
+                                                                 - 1)];
+}
+
+// Helper function to generate CDATA sections
+std::string generateCDATA(FuzzedDataProvider& fuzz_data)
+{
+    std::string cdata = "<![CDATA[";
+
+    size_t len = fuzz_data.ConsumeIntegralInRange<size_t>(0, 32);
+    for (size_t i = 0; i < len; ++i)
+    {
+        switch (fuzz_data.ConsumeIntegralInRange<int>(0, 4))
+        {
+        case 0:
+            cdata += "]]"; // Almost closing
+            break;
+        case 1:
+            cdata += "]>"; // Partial closing
+            break;
+        case 2:
+            cdata += "<![CDATA["; // Nested CDATA start
+            break;
+        case 3:
+            cdata += fuzz_data.ConsumeRandomLengthString(4); // Random content
+            break;
+        case 4:
+            cdata += "]]>]]>"; // Multiple closing attempts
+            break;
+        }
+    }
+
+    cdata += "]]>";
+    return cdata;
+}
+
+// Helper function to generate comments
+std::string generateComment(FuzzedDataProvider& fuzz_data)
+{
+    std::string comment = "<!--";
+
+    size_t len = fuzz_data.ConsumeIntegralInRange<size_t>(0, 32);
+    for (size_t i = 0; i < len; ++i)
+    {
+        switch (fuzz_data.ConsumeIntegralInRange<int>(0, 4))
+        {
+        case 0:
+            comment += "--"; // Double dash inside comment
+            break;
+        case 1:
+            comment += "-->"; // Early closing
+            break;
+        case 2:
+            comment += "<!--"; // Nested comment start
+            break;
+        case 3:
+            comment += fuzz_data.ConsumeRandomLengthString(4); // Random content
+            break;
+        case 4:
+            comment += "--->"; // Malformed closing
+            break;
+        }
+    }
+
+    comment += "-->";
+    return comment;
+}
+
+// Helper function to generate text content
+std::string generateText(FuzzedDataProvider& fuzz_data)
+{
+    std::string text;
+    size_t      len = fuzz_data.ConsumeIntegralInRange<size_t>(0, 32);
+
+    for (size_t i = 0; i < len; ++i)
+    {
+        switch (fuzz_data.ConsumeIntegralInRange<int>(0, 3))
+        {
+        case 0: // Normal text
+            text += fuzz_data.ConsumeRandomLengthString(4);
+            break;
+        case 1: // Special XML characters
+            text += "<>&'\"";
+            break;
+        case 2: // Entity references
+            text += generateEntityRef(fuzz_data);
+            break;
+        case 3: // Control characters
+            text += static_cast<char>(fuzz_data.ConsumeIntegralInRange<int>(0, 31));
+            break;
+        }
+    }
+    return text;
+}
+
+// Helper function to generate nested XML elements
+std::string generateXML(FuzzedDataProvider& fuzz_data, int depth = 0)
+{
+    if (depth > 5 || fuzz_data.remaining_bytes() < 2)
+    {
+        return generateText(fuzz_data);
+    }
+
+    std::string xml;
+
+    // Add pre-content
+    if (fuzz_data.ConsumeBool())
+    {
+        switch (fuzz_data.ConsumeIntegralInRange<int>(0, 2))
+        {
+        case 0:
+            xml += generateComment(fuzz_data);
+            break;
+        case 1:
+            xml += generateCDATA(fuzz_data);
+            break;
+        case 2:
+            xml += generateText(fuzz_data);
+            break;
+        }
+    }
+
+    // Generate element
+    std::string tag = generateTagName(fuzz_data);
+    xml += "<" + tag;
+
+    // Maybe make it a self-closing tag
+    if (depth > 3 || fuzz_data.ConsumeBool())
+    {
+        xml += "/>";
+        return xml;
+    }
+
+    xml += ">";
+
+    // Add content
+    size_t children = fuzz_data.ConsumeIntegralInRange<size_t>(0, 5);
+    for (size_t i = 0; i < children; ++i)
+    {
+        switch (fuzz_data.ConsumeIntegralInRange<int>(0, 4))
+        {
+        case 0:
+            xml += generateXML(fuzz_data, depth + 1);
+            break;
+        case 1:
+            xml += generateComment(fuzz_data);
+            break;
+        case 2:
+            xml += generateCDATA(fuzz_data);
+            break;
+        case 3:
+            xml += generateText(fuzz_data);
+            break;
+        case 4:
+            xml += generateEntityRef(fuzz_data);
+            break;
+        }
+    }
+
+    // Add closing tag (sometimes intentionally wrong)
+    if (fuzz_data.ConsumeBool())
+    {
+        xml += "</" + tag + ">";
+    }
+    else
+    {
+        // Generate malformed closing tags
+        switch (fuzz_data.ConsumeIntegralInRange<int>(0, 4))
+        {
+        case 0:
+            xml += "</" + generateTagName(fuzz_data) + ">"; // Wrong tag
+            break;
+        case 1:
+            xml += "</" + tag; // Missing >
+            break;
+        case 2:
+            xml += "</ " + tag + ">"; // Space after /
+            break;
+        case 3:
+            xml += "<"; // Incomplete closing
+            break;
+        case 4:
+            // No closing tag at all
+            break;
+        }
+    }
+
+    return xml;
+}
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t* Data, size_t Size)
+{
+    if (Size < 4)
+        return 0; // Require minimum input size
+
+    FuzzedDataProvider fuzz_data(Data, Size);
+
+    // Generate XML with probability
+    std::string input;
+    if (fuzz_data.ConsumeBool())
+    {
+        // Generate well-formed XML
+        input = generateXML(fuzz_data);
+    }
+    else
+    {
+        // Generate potentially malformed XML
+        while (fuzz_data.remaining_bytes() > 0)
+        {
+            switch (fuzz_data.ConsumeIntegralInRange<int>(0, 6))
+            {
+            case 0: // Tags
+                input += "<" + generateTagName(fuzz_data) + ">";
+                break;
+            case 1: // Text
+                input += generateText(fuzz_data);
+                break;
+            case 2: // Comments
+                input += generateComment(fuzz_data);
+                break;
+            case 3: // CDATA
+                input += generateCDATA(fuzz_data);
+                break;
+            case 4: // Entity references
+                input += generateEntityRef(fuzz_data);
+                break;
+            case 5: // Random XML-like content
+                input += "<" + fuzz_data.ConsumeRandomLengthString(8) + ">"
+                         + fuzz_data.ConsumeRandomLengthString(16) + "</"
+                         + fuzz_data.ConsumeRandomLengthString(8) + ">";
+                break;
+            case 6: // Random bytes
+                input += fuzz_data.ConsumeRandomLengthString(16);
+                break;
+            }
+        }
+    }
+
+    // Create a buffer from the generated input
+    auto buffer = lexy::buffer<lexy::utf8_encoding>(input.data(), input.size());
+
+    // Try to parse the XML
+    auto result = lexy::parse<grammar::document>(buffer, lexy_ext::report_error);
+
+    if (result.has_value())
+    {
+        // For valid XML, also test the printing functionality
+        result.value()->print();
+    }
+
+    return 0;
+}


### PR DESCRIPTION
I am not sure if you're interested in this, but I was playing around with fuzzing harnesses for `lexy` for verification. I came up with a couple and dirty ones that can be built with both [libfuzzer](https://llvm.org/docs/LibFuzzer.html) and [AFL++](https://github.com/AFLplusplus/AFLplusplus). Could not find any obvious low-hanging fruits so far. I figured sharing would not hurt..

Cheers