### PR TITLE
Fix CMake Deprecation Warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (C) 2020-2025 Jonathan Müller and lexy contributors
 # SPDX-License-Identifier: BSL-1.0
 
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.8...3.10)
 project(lexy VERSION 2022.12.1 LANGUAGES CXX)
 
 set(LEXY_USER_CONFIG_HEADER "" CACHE FILEPATH "The user config header for lexy.")


### PR DESCRIPTION
CMake Deprecation Warning at build/_deps/lexy-src/CMakeLists.txt:4 (cmake_minimum_required):Compatibility with CMake <3.10 will be removed from a future version of CMake.

Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax to tell CMake that the project requires at least <min> but has been updated to work with policies introduced by <max> or earlier.

See [https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-version](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#policy-version) for more details.