### PR TITLE
playground: fix compiler-explorer URL paths

### DIFF
--- a/docs/assets/js/playground.js
+++ b/docs/assets/js/playground.js
@@ -1,4 +1,4 @@
-const api = "https://godbolt.org/api/";
+const compiler_explorer_host = "https://godbolt.org";
 const compiler_id = "clang_trunk";
 const lexy_id = { id: 'lexy', version: 'trunk' };
 
@@ -78,7 +78,8 @@ export async function compile_and_run(source, input, mode)
 
     body.lang = "c++";
 
-    const response = await fetch(`${api}/compiler/${compiler_id}/compile`, {
+    const url = new URL(`/api/compiler/${compiler_id}/compile`, compiler_explorer_host);
+    const response = await fetch(url, {
         method: "POST",
         headers: { 'Content-Type': 'application/json', 'Accept': 'application/json' },
         body: json_stringify(body)
@@ -129,7 +130,8 @@ function get_godbolt_clientstate(source, input)
 export async function get_godbolt_permalink(source, input)
 {
     const state = get_godbolt_clientstate(source, input);
-    const response = await fetch(api + "shortener", {
+    const url = new URL(`/api/shortener`, compiler_explorer_host);
+    const response = await fetch(url, {
         method: "POST",
         headers: { "Content-Type": "application/json", "Accept": "application/json" },
         body: json_stringify(state)
@@ -143,7 +145,8 @@ export function get_godbolt_url(source, input)
 {
     const state = get_godbolt_clientstate(source, input);
     const state_str = json_stringify(state);
-    return "https://godbolt.org/clientstate/" + encodeURIComponent(btoa(state_str));
+    const encoded_state = encodeURIComponent(btoa(state_str));
+    return new URL(`/clientstate/${encoded_state}`, compiler_explorer_host);
 }
 
 export async function load_example(url)
@@ -159,7 +162,8 @@ export async function load_example(url)
 
 export async function load_godbolt_url(id)
 {
-    const response = await fetch(api + "shortlinkinfo/" + id);
+    const url = new URL(`/api/shortlinkinfo/${id}`, compiler_explorer_host);
+    const response = await fetch(url);
     if (!response.ok)
         return { grammar: "", input: "", production: "" };
     const result = await response.json();

--- a/support/generate-unicode-db.py
+++ b/support/generate-unicode-db.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # Generate the header file containing the Unicode database.
 # It uses the three stage approach described e.g. here https://here-be-braces.com/fast-lookup-of-unicode-properties/.
 # For case folding, it stores the offset to the simple case folded code point.

--- a/support/resolve-lexy-headers.py
+++ b/support/resolve-lexy-headers.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # Replaces all lexy includes of the input file with the header contents, recursively.
 # As an optimization, it does not resolve the same header twice.
 


### PR DESCRIPTION
fixes: #231

```markdown
playground: fix compiler-explorer URL paths

the lexy playground had previously been making POSTs against
compiler-explorer with urls that had duplicate '/'s, eg:

  "https://godbolt.org/api//compiler/clang_trunk/compile"

compiler-explorer recently started rejecting these. This replaces the
previous string-based url definitions with arrow-expression lambdas and
javascript URL objects, in an effort to prevent that from happening
again.

1 file changed, 12 insertions(+), 5 deletions(-)
docs/assets/js/playground.js | 17 ++++++++++++-----
```