### PR TITLE
cmake: use generator expressions for paths, alter `set(... PARENT_SCOPE)` use

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Copyright (C) 2020-2025 Jonathan Müller and lexy contributors
 # SPDX-License-Identifier: BSL-1.0
 
-get_filename_component(include_dir ${CMAKE_CURRENT_SOURCE_DIR}/../include/lexy ABSOLUTE)
-get_filename_component(ext_include_dir ${CMAKE_CURRENT_SOURCE_DIR}/../include/lexy_ext ABSOLUTE)
+set(include_dir "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include/lexy>$<INSTALL_INTERFACE:include/lexy>")
+set(ext_include_dir "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../include_lexy_ext>$<INSTALL_INTERFACE:include/lexy_ext>")
 set(header_files
         ${include_dir}/_detail/any_ref.hpp
         ${include_dir}/_detail/assert.hpp
@@ -210,7 +210,7 @@ endif()
 add_library(lexy_file STATIC)
 add_alias(lexy::file lexy_file)
 target_link_libraries(lexy_file PRIVATE foonathan::lexy::dev)
-target_sources(lexy_file PRIVATE input/file.cpp)
+target_sources(lexy_file PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/input/file.cpp)
 
 # Link to enable unicode database.
 add_library(lexy_unicode INTERFACE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,14 +121,16 @@ set(header_files
         ${include_dir}/parse_tree.hpp
         ${include_dir}/token.hpp
         ${include_dir}/visualize.hpp
-        PARENT_SCOPE)
+)
+set(header_files ${header_files} PARENT_SCOPE)
 set(ext_header_files
         ${ext_include_dir}/compiler_explorer.hpp
         ${ext_include_dir}/parse_tree_algorithm.hpp
         ${ext_include_dir}/parse_tree_doctest.hpp
         ${ext_include_dir}/report_error.hpp
         ${ext_include_dir}/shell.hpp
-        PARENT_SCOPE)
+)
+set(ext_header_files ${ext_header_files} PARENT_SCOPE)
 
 # Base target for common options.
 add_library(_lexy_base INTERFACE)


### PR DESCRIPTION
```
commit c87722ab17fc2ea4b82ef205aff059d0bcbd13f4
Author: Nicholas Sielicki <opensource@nslick.com>
Date:   Mon Jun 23 02:44:14 2025 -0700

    cmake: use generator expression for includedir

    avoid resolving stale paths after install

    Signed-off-by: Nicholas Sielicki <opensource@nslick.com>

commit 64ed2ebff4c603346aeb10c383ce6c31f05afa40
Author: Nicholas Sielicki <opensource@nslick.com>
Date:   Mon Jun 23 00:47:54 2025 -0700

    cmake: do not exclusively set() in parent scope

    under some external uses, cmake would error with:
    > CMake Error (dev) at <...>/src/CMakeLists.txt:135 (target_sources):
    >   uninitialized variable 'header_files'
    > CMake Error (dev) at <...>/src/CMakeLists.txt:221 (target_sources):
    >   uninitialized variable 'ext_header_files'

    This is because the set() calls at the top of the file previously passed
    PARENT_SCOPE, which does not only propagate these these vars to the
    parent scope, but also results in them retaining an unset state in the
    current scope. Quoting from the cmake docs for command/set:

    > If the PARENT_SCOPE option is given the variable will be set in the
    > scope above the current scope. [...] The previous state of the
    > variable's value stays the same in the current scope (e.g., if it was
    > undefined before, it is still undefined and if it had a value, it is
    > still that value)

    It's unclear to me why some build workflows encounter this and others do
    not, as well as why the top-level CMakeLists.txt in lexy requires these
    variables to be inserted into its scope (it does not seem to reference
    them directly). So because I don't understand that, and in the interest
    of not breaking any existing workflows while still fixing file-local
    uses of these vars, add a second set() call which continues to pass
    PARENT_SCOPE.

    Signed-off-by: Nicholas Sielicki <opensource@nslick.com>
```

As mentioned above, I don't fully understand why `PARENT_SCOPE` was there in the first place, so I'm opening this as a draft pull request in case I'm missing something obvious and you have more context.