### PR TITLE
Add missing header files dsl/list.hpp and dsl/literal.hpp to src/CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,6 +73,8 @@ set(header_files
         ${include_dir}/dsl/identifier.hpp
         ${include_dir}/dsl/if.hpp
         ${include_dir}/dsl/integer.hpp
+        ${include_dir}/dsl/list.hpp
+        ${include_dir}/dsl/literal.hpp
         ${include_dir}/dsl/lookahead.hpp
         ${include_dir}/dsl/loop.hpp
         ${include_dir}/dsl/member.hpp


### PR DESCRIPTION
Hi Jonathan,

While porting your library to Bazel in a private project, I found that two header files are missing in the header_files.
I added "${include_dir}/dsl/list.hpp" and "$(include_dir}/dsl/literal.hpp" to "${header_files}" in "src/CMakeLists.txt".

best regards,
Fabian